### PR TITLE
Convert popular movies to popular TV shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,36 @@
-# popular-movies
+# popular-TV
 
-Popular Movies uses LLMs to evaluate the popularity of movies that are released
-and are less than 4 months old. Popular Movies considers a multitude of data points
-such as ratings, popularity, production companies, actors, and more.
+Popular TV uses LLMs to evaluate the popularity of TV shows with episodes that aired
+in the last 4 months. Popular TV considers a multitude of data points
+such as ratings, popularity, networks, production companies, actors, creators, and more.
 
 ## Usage
 
-> :warning: **The URL has changed from `https://s3.amazonaws.com/popular-movies/` to `https://popular-movies-data.stevenlu.com/` as of September 11, 2023.**
-> Access via S3 using TLS 1.0 or 1.1 will be [deprecated by AWS](https://aws.amazon.com/blogs/security/tls-1-2-required-for-aws-endpoints/) on December 31, 2023.
-> Access via S3 will be completely deprecated January 1, 2025.
-
-You can poll the following JSON file for a list of movies.
+When deployed, you can poll the following JSON file for a list of TV shows.
 
 ```
-https://popular-movies-data.stevenlu.com/movies.json
+https://your-domain.com/tv-shows.json
 ```
 
   * This file is regenerated nightly so it is recommended that you
     only poll this file once per day
   * It is recommended that you take a snapshot of this list and not
-    remove based on the list no longer displaying a particular movie
+    remove based on the list no longer displaying a particular TV show
   * Subject to fair use; excessive usage will be rate limited
 
 If you're looking for historical files, you can amend a date to the
 main file like so:
 
 ```
-https://popular-movies-data.stevenlu.com/movies-20191202.json
+https://your-domain.com/tv-shows-20191202.json
 ```
 
-_This file is only available from December 2, 2019 onwards._
+## All TV Shows
 
-## All Movies
-
-There is also a file that includes all movies. This file is not filtered or evaluated.
+There is also a file that includes all TV shows. This file is not filtered or evaluated.
 
 ```
-https://popular-movies-data.stevenlu.com/all-movies.json
+https://your-domain.com/all-tv-shows.json
 ```
 
 There are also several variations of this file that are filtered by different
@@ -44,18 +38,18 @@ rating websites.
 
 | File | Description |
 | -- | -- |
-| [movies-metacritic-min50.json](https://popular-movies-data.stevenlu.com/movies-metacritic-min50.json) | Movies with a minimum score of 50 on Metacritic |
-| [movies-metacritic-min60.json](https://popular-movies-data.stevenlu.com/movies-metacritic-min60.json) | Movies with a minimum score of 60 on Metacritic |
-| [movies-metacritic-min70.json](https://popular-movies-data.stevenlu.com/movies-metacritic-min70.json) | Movies with a minimum score of 70 on Metacritic |
-| [movies-metacritic-min80.json](https://popular-movies-data.stevenlu.com/movies-metacritic-min80.json) | Movies with a minimum score of 80 on Metacritic |
-| [movies-imdb-min5.json](https://popular-movies-data.stevenlu.com/movies-imdb-min5.json) | Movies with a minimum score of 5 on IMDB |
-| [movies-imdb-min6.json](https://popular-movies-data.stevenlu.com/movies-imdb-min6.json) | Movies with a minimum score of 6 on IMDB |
-| [movies-imdb-min7.json](https://popular-movies-data.stevenlu.com/movies-imdb-min7.json) | Movies with a minimum score of 7 on IMDB |
-| [movies-imdb-min8.json](https://popular-movies-data.stevenlu.com/movies-imdb-min8.json) | Movies with a minimum score of 8 on IMDB |
-| [movies-rottentomatoes-min50.json](https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min50.json) | Movies with a minimum score of 50 on Rotten Tomatoes |
-| [movies-rottentomatoes-min60.json](https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min60.json) | Movies with a minimum score of 60 on Rotten Tomatoes |
-| [movies-rottentomatoes-min70.json](https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min70.json) | Movies with a minimum score of 70 on Rotten Tomatoes |
-| [movies-rottentomatoes-min80.json](https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min80.json) | Movies with a minimum score of 80 on Rotten Tomatoes |
+| tv-shows-metacritic-min50.json | TV shows with a minimum score of 50 on Metacritic |
+| tv-shows-metacritic-min60.json | TV shows with a minimum score of 60 on Metacritic |
+| tv-shows-metacritic-min70.json | TV shows with a minimum score of 70 on Metacritic |
+| tv-shows-metacritic-min80.json | TV shows with a minimum score of 80 on Metacritic |
+| tv-shows-imdb-min5.json | TV shows with a minimum score of 5 on IMDB |
+| tv-shows-imdb-min6.json | TV shows with a minimum score of 6 on IMDB |
+| tv-shows-imdb-min7.json | TV shows with a minimum score of 7 on IMDB |
+| tv-shows-imdb-min8.json | TV shows with a minimum score of 8 on IMDB |
+| tv-shows-rottentomatoes-min50.json | TV shows with a minimum score of 50 on Rotten Tomatoes |
+| tv-shows-rottentomatoes-min60.json | TV shows with a minimum score of 60 on Rotten Tomatoes |
+| tv-shows-rottentomatoes-min70.json | TV shows with a minimum score of 70 on Rotten Tomatoes |
+| tv-shows-rottentomatoes-min80.json | TV shows with a minimum score of 80 on Rotten Tomatoes |
 
 
 ## Develop

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -46,84 +46,84 @@ Promise
   .then(function () {
     return [
       {
-        filename: 'movies.json',
+        filename: 'tv-shows.json',
         evaluate: true
       },
       {
-        filename: `movies-${moment().format('YYYYMMDD')}.json`,
+        filename: `tv-shows-${moment().format('YYYYMMDD')}.json`,
         evaluate: true
       },
       {
-        filename: 'all-movies.json'
+        filename: 'all-tv-shows.json'
       },
       {
-        filename: 'movies-metacritic-min50.json',
+        filename: 'tv-shows-metacritic-min50.json',
         opts: {
           min_metacritic_score: 50
         }
       },
       {
-        filename: 'movies-metacritic-min60.json',
+        filename: 'tv-shows-metacritic-min60.json',
         opts: {
           min_metacritic_score: 60
         }
       },
       {
-        filename: 'movies-metacritic-min70.json',
+        filename: 'tv-shows-metacritic-min70.json',
         opts: {
           min_metacritic_score: 70
         }
       },
       {
-        filename: 'movies-metacritic-min80.json',
+        filename: 'tv-shows-metacritic-min80.json',
         opts: {
           min_metacritic_score: 80
         }
       },
       {
-        filename: 'movies-imdb-min5.json',
+        filename: 'tv-shows-imdb-min5.json',
         opts: {
           min_imdb_rating: 5
         }
       },
       {
-        filename: 'movies-imdb-min6.json',
+        filename: 'tv-shows-imdb-min6.json',
         opts: {
           min_imdb_rating: 6
         }
       },
       {
-        filename: 'movies-imdb-min7.json',
+        filename: 'tv-shows-imdb-min7.json',
         opts: {
           min_imdb_rating: 7
         }
       },
       {
-        filename: 'movies-imdb-min8.json',
+        filename: 'tv-shows-imdb-min8.json',
         opts: {
           min_imdb_rating: 8
         }
       },
       {
-        filename: 'movies-rottentomatoes-min50.json',
+        filename: 'tv-shows-rottentomatoes-min50.json',
         opts: {
           min_rt_score: 50
         }
       },
       {
-        filename: 'movies-rottentomatoes-min60.json',
+        filename: 'tv-shows-rottentomatoes-min60.json',
         opts: {
           min_rt_score: 60
         }
       },
       {
-        filename: 'movies-rottentomatoes-min70.json',
+        filename: 'tv-shows-rottentomatoes-min70.json',
         opts: {
           min_rt_score: 70
         }
       },
       {
-        filename: 'movies-rottentomatoes-min80.json',
+        filename: 'tv-shows-rottentomatoes-min80.json',
         opts: {
           min_rt_score: 80
         }

--- a/lib/metacritic.js
+++ b/lib/metacritic.js
@@ -6,19 +6,18 @@ const moment = require('moment')
 
 async function metacriticRequest (opts) {
   return await request(_.defaultsDeep(opts, {
-    url: 'https://www.metacritic.com/browse/movie/all/all/all-time/new/',
+    url: 'https://www.metacritic.com/browse/tv/all/all/all-time/new/',
     headers: {
       'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
     },
     qs: {
-      releaseType: 'in-theaters',
       releaseYearMin: moment().subtract(12, 'months').year(),
       page: 1
     }
   }))
 }
 
-async function getMovies (page = 1) {
+async function getTvShows (page = 1) {
   return Promise
     .resolve()
     .then(function () {
@@ -36,30 +35,30 @@ async function getMovies (page = 1) {
       const $ = cheerio.load(resp.body)
       return $('.c-finderProductCard').toArray()
     })
-    .map(function (movie) {
-      const $movie = cheerio.load(movie)
+    .map(function (show) {
+      const $show = cheerio.load(show)
 
       return {
-        title: $movie('.c-finderProductCard_title').text().trim(),
-        score: _.parseInt($movie('.c-siteReviewScore').first().text().trim())
+        title: $show('.c-finderProductCard_title').text().trim(),
+        score: _.parseInt($show('.c-siteReviewScore').first().text().trim())
       }
     })
-    .then(function (movies) {
-      return _.reject(movies, function (movie) {
-        return movie.title.length === 0 || movie.score === 'tbd'
+    .then(function (shows) {
+      return _.reject(shows, function (show) {
+        return show.title.length === 0 || show.score === 'tbd'
       })
     })
 }
 
 module.exports = async function () {
-  const movies = []
+  const shows = []
   let page = 1
-  let movieResults = await getMovies(page)
-  while (movieResults.length > 0 && page < 20) {
-    movies.push(...movieResults)
+  let showResults = await getTvShows(page)
+  while (showResults.length > 0 && page < 20) {
+    shows.push(...showResults)
     page++
-    movieResults = await getMovies(page)
+    showResults = await getTvShows(page)
   }
 
-  return movies
+  return shows
 }

--- a/lib/tmdb.js
+++ b/lib/tmdb.js
@@ -38,52 +38,55 @@ const makeRequest = function (url, data) {
     })
 }
 
-const formatMovie = function (movie) {
-  const details = _.pick(movie, [
+const formatTvShow = function (tvShow) {
+  const details = _.pick(tvShow, [
     'id',
-    'title',
-    'release_date',
+    'name',
+    'first_air_date',
     'popularity',
     'vote_average',
     'vote_count',
     'poster_path'
   ])
+  // Use 'name' as 'title' for consistency with the rest of the codebase
+  details.title = details.name
+  delete details.name
+  details.release_date = details.first_air_date // Map to release_date for consistency
   details.poster_url = config.TMDB_POSTER_URL + details.poster_path
   return details
 }
 
-const getMovies = function (page) {
-  return makeRequest('/discover/movie', {
+const getTvShows = function (page) {
+  return makeRequest('/discover/tv', {
     sort_by: 'popularity.desc',
     'vote_count.gte': 100,
     'vote_average.gte': 4,
     page: page || 1,
     language: 'en-US',
-    region: 'US',
-    'release_date.gte': moment().subtract(4, 'months').format('YYYY-MM-DD'),
-    'release_date.lte': moment().format('YYYY-MM-DD')
+    'first_air_date.gte': moment().subtract(4, 'months').format('YYYY-MM-DD'),
+    'first_air_date.lte': moment().format('YYYY-MM-DD')
   })
 }
 
 module.exports.getMovies = async function () {
-  const firstResponse = await getMovies()
-  let allMovies = [...firstResponse.results]
+  const firstResponse = await getTvShows()
+  let allShows = [...firstResponse.results]
 
   // Fetch remaining pages
   const remainingPages = _.range(firstResponse.page, firstResponse.total_pages)
   for (const page of remainingPages) {
-    const response = await getMovies(page)
-    allMovies.push(...response.results)
+    const response = await getTvShows(page)
+    allShows.push(...response.results)
   }
 
-  // Clean and format movies
-  allMovies = _.compact(allMovies)
-  return allMovies.map(movie => formatMovie(movie))
+  // Clean and format TV shows
+  allShows = _.compact(allShows)
+  return allShows.map(show => formatTvShow(show))
 }
 
 module.exports.getMovie = function (id) {
-  return makeRequest('/movie/' + id, {
-    append_to_response: 'credits'
+  return makeRequest('/tv/' + id, {
+    append_to_response: 'credits,external_ids'
   })
 }
 
@@ -93,14 +96,14 @@ module.exports.searchMovie = function (title, year) {
   }
 
   if (year) {
-    query.year = year
+    query.first_air_date_year = year
   }
 
-  return makeRequest('/search/movie', query)
+  return makeRequest('/search/tv', query)
     .then(function (results) {
       return _.first(results.results)
     })
-    .then(function (movie) {
-      return formatMovie(movie)
+    .then(function (show) {
+      return formatTvShow(show)
     })
 }


### PR DESCRIPTION
This commit transforms the popular movies list into a popular TV shows list with the following changes:

- Updated TMDB integration to use TV show endpoints (/discover/tv, /tv/{id}, /search/tv)
- Modified data fields to reflect TV show properties (seasons, episodes, networks, creators)
- Updated Metacritic scraper to fetch TV show data instead of movies
- Revised Claude AI evaluation prompt to assess TV show popularity
- Changed all output filenames from movies-* to tv-shows-*
- Updated README documentation to reflect TV show focus
- Removed movie-specific fields (budget, revenue, director) and added TV-specific fields (number_of_seasons, number_of_episodes, networks, creators)

The core data pipeline and rating integrations (OMDB, IMDb) remain compatible with TV shows.