### PR TITLE
Redesign: modern poster grid with filter bar and dark mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -270,6 +270,7 @@ async function fetchAndRender() {
     const parsed = raw
       .map(m => ({
         title:      m.title,
+        imdb_id:    m.imdb_id || null,
         /* normalise http → https to avoid mixed-content blocks */
         poster_url: (m.poster_url || m.poster || '').replace(/^http:\/\//, 'https://') || null,
       }))
@@ -330,7 +331,7 @@ function renderGrid() {
     const delay = animateNext ? `animation-delay:${Math.min(i * 28, 520)}ms` : '';
 
     return `
-      <a href="https://www.imdb.com/find/?q=${encodeURIComponent(m.title)}"
+      <a href="${m.imdb_id ? `https://www.imdb.com/title/${m.imdb_id}/` : `https://www.imdb.com/find/?q=${encodeURIComponent(m.title)}`}"
          target="_blank" rel="noopener"
          class="block ${animateNext ? 'anim' : ''}"
          style="${delay}">

--- a/app.js
+++ b/app.js
@@ -88,18 +88,15 @@ themeBtn.addEventListener('click', () => {
    FILTER BAR
 ════════════════════════════════════════════════════════ */
 
-/* Tailwind classes for a chip based on its active state */
-function chipClasses(active) {
-  const base = 'h-8 px-3.5 text-xs inline-flex items-center gap-1.5 cursor-pointer transition-colors whitespace-nowrap';
-  return active
-    ? `${base} font-semibold rounded-full border border-transparent`
-    : `${base} rounded-full border`;
+/* "Popular" / "All" — text tabs with animated underline, no border/background */
+function chipClasses() {
+  return 'h-8 px-1 text-sm inline-flex items-center cursor-pointer whitespace-nowrap bg-transparent border-0 rounded-none';
 }
 
 function chipStyle(active) {
   return active
-    ? `background:color-mix(in srgb,var(--accent) 16%,transparent);color:var(--accent)`
-    : `background:var(--card);color:var(--fg);border-color:var(--line)`;
+    ? `color:var(--fg);font-weight:700;box-shadow:inset 0 -2px 0 var(--accent);transition:color .25s ease,box-shadow .25s ease`
+    : `color:var(--muted);font-weight:400;box-shadow:inset 0 0 0 transparent;transition:color .25s ease,box-shadow .25s ease`;
 }
 
 /* Segmented group cell (no outer border-radius, shares a border) */

--- a/app.js
+++ b/app.js
@@ -304,8 +304,6 @@ function renderGrid() {
   const grid  = document.getElementById('grid');
   const empty = document.getElementById('emptyNote');
 
-  document.getElementById('countLabel').textContent = movies.length;
-
   if (!movies.length) {
     grid.innerHTML    = '';
     empty.textContent = state.provider === 'populaires'

--- a/app.js
+++ b/app.js
@@ -143,8 +143,9 @@ function buildFilterBar() {
   const threshDef  = THRESHOLDS[state.provider];
   const threshHtml = threshDef ? buildThresholdHtml(threshDef) : '';
 
-  /* Vertical divider */
-  const div = `<span class="w-px h-5 shrink-0" style="background:var(--line)"></span>`;
+  /* Vertical divider — the one before the slider is hidden at ≤480px */
+  const div      = `<span class="w-px h-5 shrink-0" style="background:var(--line)"></span>`;
+  const divThresh = `<span class="w-px h-5 shrink-0 max-[480px]:hidden" style="background:var(--line)"></span>`;
 
   bar.innerHTML = `
     <div class="flex flex-wrap items-center gap-3">
@@ -154,7 +155,10 @@ function buildFilterBar() {
            style="border-color:var(--line)">
         ${platformCells}
       </div>
-      ${threshHtml ? `${div}${threshHtml}` : ''}
+      ${threshHtml ? `
+        ${divThresh}
+        <div class="max-[480px]:w-full">${threshHtml}</div>
+      ` : ''}
     </div>
     <span id="loadState" class="ml-auto text-xs" style="color:var(--muted)"></span>
   `;

--- a/app.js
+++ b/app.js
@@ -116,13 +116,16 @@ function buildFilterBar() {
   const bar = document.getElementById('filterBar');
 
   /* "Popular" and "All" — standalone pill chips */
-  const simplePills = PROVIDERS
-    .filter(([k]) => k === 'populaires' || k === 'tous')
-    .map(([k, label]) => `
-      <button class="${chipClasses(state.provider === k)}"
-              style="${chipStyle(state.provider === k)}"
-              data-prov="${k}">${label}</button>
-    `).join('');
+  /* 6px gap between the two tabs, isolated from the outer gap-3 */
+  const simplePills = `<div class="flex items-center gap-1.5">${
+    PROVIDERS
+      .filter(([k]) => k === 'populaires' || k === 'tous')
+      .map(([k, label]) => `
+        <button class="${chipClasses()}"
+                style="${chipStyle(state.provider === k)}"
+                data-prov="${k}">${label}</button>
+      `).join('')
+  }</div>`;
 
   /* IMDB / RT / Metacritic — grouped in a segmented control */
   const platformCells = PROVIDERS

--- a/app.js
+++ b/app.js
@@ -1,0 +1,379 @@
+/* ════════════════════════════════════════════════════════
+   CONFIGURATION
+════════════════════════════════════════════════════════ */
+
+const BASE = 'https://popular-movies-data.stevenlu.com/';
+
+/* One accent colour is picked at random on every page load */
+const ACCENTS = [
+  '#3b82f6', '#ef4444', '#f59e0b', '#10b981',
+  '#8b5cf6', '#ec4899', '#0ea5e9', '#e11d48', '#14b8a6',
+];
+
+/* [url-key, display label] */
+const PROVIDERS = [
+  ['populaires',     'Popular'],
+  ['tous',           'All'],
+  ['imdb',           'IMDB'],
+  ['rottentomatoes', 'Rotten Tomatoes'],
+  ['metacritic',     'Metacritic'],
+];
+
+/* Valid min-score values per review platform */
+const THRESHOLDS = {
+  imdb:           [5, 6, 7, 8],
+  rottentomatoes: [50, 60, 70, 80],
+  metacritic:     [50, 60, 70, 80],
+};
+
+/* Inline SVGs — avoids any external icon dependency */
+const PROV_ICON = {
+  imdb: `<svg width="32" height="16" viewBox="0 0 575 289.83" aria-hidden="true">
+    <path d="M575 24.91C573.44 12.15 563.97 1.98 551.91 0C499.05 0 76.18 0 23.32 0C10.11 2.17 0 14.16 0 28.61C0 51.84 0 237.64 0 260.86C0 276.86 12.37 289.83 27.64 289.83C79.63 289.83 495.6 289.83 547.59 289.83C561.65 289.83 573.26 278.82 575 264.57C575 216.64 575 48.87 575 24.91Z" fill="#f6c700"/>
+    <path d="M69.35 58.24H114.98V233.89H69.35Z M201.2 139.15C197.28 112.38 195.1 97.5 194.67 94.53C192.76 80.2 190.94 67.73 189.2 57.09H130.04V232.74H170.01L170.15 116.76L186.97 232.74H215.44L231.39 114.18L231.54 232.74H271.38V57.09H211.77L201.2 139.15Z M346.71 93.63C347.21 95.87 347.47 100.95 347.47 108.89V176.99C347.47 188.68 346.71 195.84 345.2 198.48C343.68 201.12 339.64 202.43 333.09 202.43V87.13C338.06 87.13 341.45 87.66 343.25 88.7C345.05 89.75 346.21 91.39 346.71 93.63ZM367.32 230.95C372.75 229.76 377.31 227.66 381.01 224.67C384.7 221.67 387.29 217.52 388.77 212.21C390.26 206.91 391.14 196.38 391.14 180.63V118.95C391.14 102.33 390.49 91.19 389.48 85.53C388.46 79.86 385.93 74.71 381.88 70.09C377.82 65.47 371.9 62.15 364.12 60.13C356.33 58.11 343.63 57.09 321.54 57.09H287.5V232.74H342.78C355.52 232.34 363.7 231.75 367.32 230.95Z M464.76 204.7C463.92 206.93 460.24 208.06 457.46 208.06C454.74 208.06 452.93 206.98 452.01 204.81C451.09 202.65 450.64 197.72 450.64 190V143.58C450.64 135.58 451.04 130.59 451.85 128.6C452.65 126.63 454.41 125.63 457.13 125.63C459.91 125.63 463.64 126.76 464.6 129.03C465.55 131.3 466.03 136.15 466.03 143.58V188.59C465.74 197.84 465.32 203.21 464.76 204.7ZM406.68 231.21H447.76C449.47 224.5 450.41 220.77 450.6 220.02C454.32 224.52 458.41 227.9 462.9 230.14C467.37 232.39 474.06 233.51 479.24 233.51C486.45 233.51 492.67 231.62 497.92 227.83C503.16 224.05 506.5 219.57 507.92 214.42C509.34 209.26 510.05 201.42 510.05 190.88V141.6C510.05 131 509.81 124.08 509.34 120.83C508.87 117.58 507.47 114.27 505.14 110.88C502.81 107.49 499.42 104.86 494.98 102.98C490.54 101.1 485.3 100.16 479.26 100.16C474.01 100.16 467.29 101.21 462.81 103.28C458.34 105.35 454.28 108.49 450.64 112.7V55.56H406.68V231.21Z" fill="#000"/>
+  </svg>`,
+  rottentomatoes: `<svg width="15" height="15" viewBox="0 0 138.75 141.25" aria-hidden="true">
+    <g fill="#f93208">
+      <path d="m20.154 40.829c-28.149 27.622-13.657 61.011-5.734 71.931 35.254 41.954 92.792 25.339 111.89-5.9071 4.7608-8.2027 22.554-53.467-23.976-78.009z"/>
+      <path d="m39.613 39.265 4.7778-8.8607 28.406-5.0384 11.119 9.2082z"/>
+    </g>
+    <path d="m39.436 8.5696 8.9682-5.2826 6.7569 15.479c3.7925-6.3226 13.79-16.316 24.939-4.6684-4.7281 1.2636-7.5161 3.8553-7.7397 8.4768 15.145-4.1697 31.343 3.2127 33.539 9.0911-10.951-4.314-27.695 10.377-41.771 2.334 0.009 15.045-12.617 16.636-19.902 17.076 2.077-4.996 5.591-9.994 1.474-14.987-7.618 8.171-13.874 10.668-33.17 4.668 4.876-1.679 14.843-11.39 24.448-11.425-6.775-2.467-12.29-2.087-17.814-1.475 2.917-3.961 12.149-15.197 28.625-8.476z" fill="#02902e"/>
+  </svg>`,
+  metacritic: `<svg width="15" height="15" viewBox="0 0 40 40" aria-hidden="true">
+    <path d="M36.978 19.49a17.49 17.49 0 1 1 0-.021" fill="#000"/>
+    <path d="m17.209 32.937 3.41-3.41-6.567-6.567c-.276-.276-.576-.622-.737-1.014-.369-.783-.53-2.004.369-2.903 1.106-1.106 2.58-.645 4.009.784l6.313 6.313 3.41-3.41-6.59-6.59c-.276-.276-.599-.691-.76-1.037-.438-.898-.415-2.027.392-2.834 1.129-1.129 2.603-.714 4.24.922l6.128 6.129 3.41-3.41L27.6 9.274c-3.364-3.364-6.52-3.249-8.686-1.083-.83.83-1.337 1.705-1.59 2.696a6.71 6.71 0 0 0-.092 2.81l-.046.047c-1.66-.691-3.549-.277-5 1.175-1.936 1.935-1.866 3.986-1.636 5.184l-.07.07-1.681-1.36-2.95 2.949c1.037.945 2.282 2.097 3.687 3.502l7.673 7.673Z" fill="#F2F2F2"/>
+    <path d="M19.982 0A20 20 0 1 0 40 20v-.024A20 20 0 0 0 19.982 0Zm-.091 4.274A15.665 15.665 0 0 1 35.57 19.921v.018A15.665 15.665 0 1 1 19.89 4.274Z" fill="#FFBD3F"/>
+  </svg>`,
+};
+
+
+/* ════════════════════════════════════════════════════════
+   STATE
+════════════════════════════════════════════════════════ */
+
+const state = {
+  theme:     'light',
+  provider:  'populaires',
+  threshold: 60,
+};
+
+/* In-memory fetch cache: url → parsed movie array */
+const cache = {};
+
+let movies      = [];
+let animateNext = false; /* true → next renderGrid() staggers card entrances */
+
+
+/* ════════════════════════════════════════════════════════
+   THEME TOGGLE
+════════════════════════════════════════════════════════ */
+
+const ICON_MOON = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>`;
+const ICON_SUN  = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>`;
+
+const themeBtn = document.getElementById('themeToggle');
+
+function applyTheme() {
+  document.documentElement.classList.toggle('dark', state.theme === 'dark');
+  themeBtn.innerHTML = state.theme === 'dark' ? ICON_SUN : ICON_MOON;
+}
+
+themeBtn.addEventListener('click', () => {
+  state.theme = state.theme === 'dark' ? 'light' : 'dark';
+  applyTheme();
+});
+
+
+/* ════════════════════════════════════════════════════════
+   FILTER BAR
+════════════════════════════════════════════════════════ */
+
+/* Tailwind classes for a chip based on its active state */
+function chipClasses(active) {
+  const base = 'h-8 px-3.5 text-xs inline-flex items-center gap-1.5 cursor-pointer transition-colors whitespace-nowrap';
+  return active
+    ? `${base} font-semibold rounded-full border border-transparent`
+    : `${base} rounded-full border`;
+}
+
+function chipStyle(active) {
+  return active
+    ? `background:color-mix(in srgb,var(--accent) 16%,transparent);color:var(--accent)`
+    : `background:var(--card);color:var(--fg);border-color:var(--line)`;
+}
+
+/* Segmented group cell (no outer border-radius, shares a border) */
+function cellClasses(active) {
+  const base = 'h-8 px-3.5 text-xs inline-flex items-center gap-1.5 cursor-pointer transition-colors whitespace-nowrap border-l';
+  return active ? `${base} font-semibold` : base;
+}
+
+function cellStyle(active) {
+  const border = 'border-color:var(--line)';
+  return active
+    ? `background:color-mix(in srgb,var(--accent) 16%,transparent);color:var(--accent);${border}`
+    : `background:var(--card);color:var(--fg);${border}`;
+}
+
+function buildFilterBar() {
+  const bar = document.getElementById('filterBar');
+
+  /* "Popular" and "All" — standalone pill chips */
+  const simplePills = PROVIDERS
+    .filter(([k]) => k === 'populaires' || k === 'tous')
+    .map(([k, label]) => `
+      <button class="${chipClasses(state.provider === k)}"
+              style="${chipStyle(state.provider === k)}"
+              data-prov="${k}">${label}</button>
+    `).join('');
+
+  /* IMDB / RT / Metacritic — grouped in a segmented control */
+  const platformCells = PROVIDERS
+    .filter(([k]) => ['imdb', 'rottentomatoes', 'metacritic'].includes(k))
+    .map(([k, label], i) => `
+      <button class="${cellClasses(state.provider === k)} ${i === 0 ? 'border-l-0' : ''}"
+              style="${cellStyle(state.provider === k)}"
+              title="${label}" data-prov="${k}">
+        ${PROV_ICON[k] || ''}
+        <span class="hidden sm:inline">${label}</span>
+      </button>
+    `).join('');
+
+  /* Threshold slider — only shown for platforms that have a score */
+  const threshDef  = THRESHOLDS[state.provider];
+  const threshHtml = threshDef ? buildThresholdHtml(threshDef) : '';
+
+  /* Vertical divider */
+  const div = `<span class="w-px h-5 shrink-0" style="background:var(--line)"></span>`;
+
+  bar.innerHTML = `
+    <div class="flex flex-wrap items-center gap-3">
+      ${simplePills}
+      ${div}
+      <div class="inline-flex items-stretch border rounded-[10px] overflow-hidden"
+           style="border-color:var(--line)">
+        ${platformCells}
+      </div>
+      ${threshHtml ? `${div}${threshHtml}` : ''}
+    </div>
+    <span id="loadState" class="ml-auto text-xs" style="color:var(--muted)"></span>
+  `;
+
+  bar.querySelectorAll('[data-prov]').forEach(btn =>
+    btn.addEventListener('click', () => selectProvider(btn.dataset.prov))
+  );
+
+  if (threshDef) wireThreshold(bar, threshDef);
+}
+
+function buildThresholdHtml(threshDef) {
+  const min  = threshDef[0];
+  const max  = threshDef[threshDef.length - 1];
+  const step = threshDef[1] - threshDef[0];
+  const pct  = ((state.threshold - min) / (max - min)) * 100;
+  const fill = `background:linear-gradient(90deg,var(--accent) ${pct}%,var(--line) ${pct}%)`;
+
+  const ticks = threshDef.map(v => `
+    <button class="text-[11px] p-0 bg-transparent border-0 cursor-pointer transition-colors
+                   tabular-nums ${state.threshold === v ? 'font-bold' : ''}"
+            style="color:${state.threshold === v ? 'var(--accent)' : 'var(--muted)'}"
+            data-th="${v}">${v}</button>
+  `).join('');
+
+  return `
+    <div class="flex flex-col gap-1" style="width:160px">
+      <span class="text-[11px]" style="color:var(--muted)">min score</span>
+      <input type="range" id="thrRange"
+             min="${min}" max="${max}" step="${step}" value="${state.threshold}"
+             class="w-full" style="${fill}">
+      <div class="flex justify-between px-px">${ticks}</div>
+    </div>
+  `;
+}
+
+function wireThreshold(scope, threshDef) {
+  const min = threshDef[0];
+  const max = threshDef[threshDef.length - 1];
+
+  /* Tick buttons snap to a discrete value */
+  scope.querySelectorAll('[data-th]').forEach(btn =>
+    btn.addEventListener('click', () => setThreshold(+btn.dataset.th))
+  );
+
+  /* Range: update fill while dragging, fetch on release */
+  const range = scope.querySelector('#thrRange');
+  if (!range) return;
+
+  range.addEventListener('input', () => {
+    const pct = ((range.value - min) / (max - min)) * 100;
+    range.style.background = `linear-gradient(90deg,var(--accent) ${pct}%,var(--line) ${pct}%)`;
+    scope.querySelectorAll('[data-th]').forEach(t =>
+      Object.assign(t.style, {
+        color:      +t.dataset.th === +range.value ? 'var(--accent)' : 'var(--muted)',
+        fontWeight: +t.dataset.th === +range.value ? '700' : '',
+      })
+    );
+  });
+
+  range.addEventListener('change', () => setThreshold(+range.value));
+}
+
+function setThreshold(v) {
+  if (v === state.threshold) return;
+  state.threshold = v;
+  buildFilterBar();
+  fetchAndRender();
+}
+
+function selectProvider(key) {
+  if (key === state.provider) { fetchAndRender(); return; }
+  state.provider = key;
+  /* Reset to a sensible default when switching platforms */
+  const t = THRESHOLDS[key];
+  if (t) state.threshold = key === 'imdb' ? 6 : 60;
+  buildFilterBar();
+  fetchAndRender();
+}
+
+
+/* ════════════════════════════════════════════════════════
+   DATA FETCHING
+════════════════════════════════════════════════════════ */
+
+function endpointUrl() {
+  if (state.provider === 'populaires') return `${BASE}movies.json`;
+  if (state.provider === 'tous')       return `${BASE}all-movies.json`;
+  return `${BASE}movies-${state.provider}-min${state.threshold}.json`;
+}
+
+async function fetchAndRender() {
+  const url = endpointUrl();
+  document.getElementById('jsonLink').href = url;
+
+  const loadState = document.getElementById('loadState');
+
+  /* Serve from memory cache to avoid redundant network calls */
+  if (cache[url]) {
+    movies = cache[url];
+    animateNext = true;
+    renderGrid();
+    return;
+  }
+
+  if (loadState) loadState.textContent = 'Loading…';
+
+  try {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Network error');
+
+    const raw = await res.json();
+    const parsed = raw
+      .map(m => ({
+        title:      m.title,
+        /* normalise http → https to avoid mixed-content blocks */
+        poster_url: (m.poster_url || m.poster || '').replace(/^http:\/\//, 'https://') || null,
+      }))
+      .filter(m => m.title);
+
+    if (!parsed.length) throw new Error('Empty response');
+    cache[url] = parsed;
+    movies     = parsed;
+    if (loadState) loadState.textContent = '';
+  } catch {
+    movies = [];
+    if (loadState) loadState.textContent = 'Source unavailable';
+  }
+
+  animateNext = true;
+  renderGrid();
+}
+
+
+/* ════════════════════════════════════════════════════════
+   GRID RENDERING
+════════════════════════════════════════════════════════ */
+
+/* Minimal HTML escaping for strings inserted into innerHTML */
+function esc(s) {
+  return (s || '').replace(/[&<>"]/g,
+    c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])
+  );
+}
+
+function renderGrid() {
+  const grid  = document.getElementById('grid');
+  const empty = document.getElementById('emptyNote');
+
+  document.getElementById('countLabel').textContent = movies.length;
+
+  if (!movies.length) {
+    grid.innerHTML    = '';
+    empty.textContent = state.provider === 'populaires'
+      ? 'No movies to display.'
+      : 'No movies for this source — try another threshold.';
+    empty.classList.remove('hidden');
+    return;
+  }
+
+  empty.classList.add('hidden');
+
+  grid.innerHTML = movies.map((m, i) => {
+    /* Diagonal stripe placeholder when no poster is available */
+    const imgHtml = m.poster_url
+      ? `<img loading="lazy" src="${esc(m.poster_url)}" alt="${esc(m.title)}"
+              class="w-full h-full object-cover block"
+              onerror="this.style.display='none';this.parentElement.classList.add('stripe')">`
+      : `<div class="stripe absolute inset-0 flex items-center justify-center p-3 text-center">
+           <span class="text-[11px] uppercase tracking-widest font-medium"
+                 style="color:var(--muted)">${esc(m.title)}</span>
+         </div>`;
+
+    /* Stagger entrance delays, capped at 520 ms for large grids */
+    const delay = animateNext ? `animation-delay:${Math.min(i * 28, 520)}ms` : '';
+
+    return `
+      <a href="https://www.imdb.com/find/?q=${encodeURIComponent(m.title)}"
+         target="_blank" rel="noopener"
+         class="block ${animateNext ? 'anim' : ''}"
+         style="${delay}">
+        <div class="poster relative rounded-[var(--radius)] overflow-hidden"
+             style="aspect-ratio:2/3;background:var(--card)">
+          ${imgHtml}
+          <div class="overlay">
+            <span class="text-white text-[13px] font-semibold leading-tight">
+              ${esc(m.title)}
+            </span>
+          </div>
+        </div>
+      </a>
+    `;
+  }).join('');
+
+  animateNext = false;
+}
+
+/* Re-trigger card entrances when the user returns to a hidden tab
+   (CSS animations are paused while a tab is not visible) */
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) return;
+  document.querySelectorAll('#grid a').forEach((el, i) => {
+    el.classList.remove('anim');
+    void el.offsetWidth; /* force reflow so animation restarts */
+    el.style.animationDelay = `${Math.min(i * 28, 520)}ms`;
+    el.classList.add('anim');
+  });
+});
+
+
+/* ════════════════════════════════════════════════════════
+   BOOT
+════════════════════════════════════════════════════════ */
+
+/* Random accent colour on every page load */
+document.documentElement.style.setProperty(
+  '--accent', ACCENTS[Math.floor(Math.random() * ACCENTS.length)]
+);
+
+applyTheme();
+buildFilterBar();
+fetchAndRender();

--- a/app.js
+++ b/app.js
@@ -145,7 +145,7 @@ function buildFilterBar() {
 
   /* Vertical divider — the one before the slider is hidden at ≤480px */
   const div      = `<span class="w-px h-5 shrink-0" style="background:var(--line)"></span>`;
-  const divThresh = `<span class="w-px h-5 shrink-0 max-[480px]:hidden" style="background:var(--line)"></span>`;
+  const divThresh = `<span class="w-px h-5 shrink-0 max-xs:hidden" style="background:var(--line)"></span>`;
 
   bar.innerHTML = `
     <div class="flex flex-wrap items-center gap-3">
@@ -157,7 +157,7 @@ function buildFilterBar() {
       </div>
       ${threshHtml ? `
         ${divThresh}
-        <div class="max-[480px]:w-full">${threshHtml}</div>
+        <div class="max-xs:w-full">${threshHtml}</div>
       ` : ''}
     </div>
     <span id="loadState" class="ml-auto text-xs" style="color:var(--muted)"></span>

--- a/app.js
+++ b/app.js
@@ -135,7 +135,7 @@ function buildFilterBar() {
               style="${cellStyle(state.provider === k)}"
               title="${label}" data-prov="${k}">
         ${PROV_ICON[k] || ''}
-        <span class="hidden sm:inline">${label}</span>
+        <span class="hidden md:inline">${label}</span>
       </button>
     `).join('');
 

--- a/index.html
+++ b/index.html
@@ -40,6 +40,34 @@
     <p>
       <a class="button button-primary" href="https://s3.amazonaws.com/popular-movies/movies.json">JSON List</a>
       <a class="button" href="https://github.com/sjlu/popular-movies" target="_blank">GitHub</a>
+
+      <span class="dropdown" style="float:right;margin-left:5px">
+        <a class="button dropdown-btn"><img src="https://www.google.com/s2/favicons?domain=metacritic.com&sz=16" width="16" height="16" style="vertical-align:middle;margin-right:4px">Metacritic</a>
+        <span class="dropdown-content">
+          <a href="https://popular-movies-data.stevenlu.com/movies-metacritic-min50.json">Min 50</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-metacritic-min60.json">Min 60</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-metacritic-min70.json">Min 70</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-metacritic-min80.json">Min 80</a>
+        </span>
+      </span>
+      <span class="dropdown" style="float:right;margin-left:5px">
+        <a class="button dropdown-btn"><img src="https://www.google.com/s2/favicons?domain=rottentomatoes.com&sz=16" width="16" height="16" style="vertical-align:middle;margin-right:4px">Rotten Tomatoes</a>
+        <span class="dropdown-content">
+          <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min50.json">Min 50</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min60.json">Min 60</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min70.json">Min 70</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min80.json">Min 80</a>
+        </span>
+      </span>
+      <span class="dropdown" style="float:right;margin-left:5px">
+        <a class="button dropdown-btn"><img src="https://www.google.com/s2/favicons?domain=imdb.com&sz=16" width="16" height="16" style="vertical-align:middle;margin-right:4px">IMDB</a>
+        <span class="dropdown-content">
+          <a href="https://popular-movies-data.stevenlu.com/movies-imdb-min5.json">Min 5</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-imdb-min6.json">Min 6</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-imdb-min7.json">Min 7</a>
+          <a href="https://popular-movies-data.stevenlu.com/movies-imdb-min8.json">Min 8</a>
+        </span>
+      </span>
     </p>
     <hr />
     <div id="posters" class="row">

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       style="background:var(--bg);color:var(--fg)">
 
   <!-- ── Header ──────────────────────────────────────── -->
-  <header class="mx-auto px-5 sm:px-8" style="max-width:var(--maxw)">
+  <header class="mx-auto px-5 sm:px-8" class="max-w-[1280px]">
 
     <!-- Title row -->
     <div class="pt-10 sm:pt-16 pb-2 flex items-start justify-between gap-4">
@@ -85,7 +85,7 @@
 
 
   <!-- ── Movie grid ───────────────────────────────────── -->
-  <main class="mx-auto px-5 sm:px-8 pb-24" style="max-width:var(--maxw)">
+  <main class="mx-auto px-5 sm:px-8 pb-24" class="max-w-[1280px]">
     <div id="grid" class="grid-movies"></div>
     <p id="emptyNote" class="hidden text-center py-20 text-sm" style="color:var(--muted)"></p>
   </main>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       style="background:var(--bg);color:var(--fg)">
 
   <!-- ── Header ──────────────────────────────────────── -->
-  <header class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <header class="max-w-[960px] mx-auto px-4 sm:px-6 lg:px-8">
 
     <!-- Title row -->
     <div class="pt-10 sm:pt-16 pb-2 flex items-start justify-between gap-4">
@@ -85,7 +85,7 @@
 
 
   <!-- ── Movie grid ───────────────────────────────────── -->
-  <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
+  <main class="max-w-[960px] mx-auto px-4 sm:px-6 lg:px-8 pb-24">
     <div id="grid" class="grid-movies"></div>
     <p id="emptyNote" class="hidden text-center py-20 text-sm" style="color:var(--muted)"></p>
   </main>

--- a/index.html
+++ b/index.html
@@ -267,5 +267,332 @@
     Original concept by Steven Lu.
   </footer>
 
+
+  <script>
+    /* ════════════════════════════════════════════════
+       CONFIGURATION
+    ════════════════════════════════════════════════ */
+
+    const BASE = 'https://popular-movies-data.stevenlu.com/';
+
+    /* Accent palette — one colour chosen at random on every page load */
+    const ACCENTS = ['#3b82f6','#ef4444','#f59e0b','#10b981','#8b5cf6','#ec4899','#0ea5e9','#e11d48','#14b8a6'];
+
+    /* Filter sources: [url key, display label] */
+    const PROVIDERS = [
+      ['populaires',     'Popular'],
+      ['tous',           'All'],
+      ['imdb',           'IMDB'],
+      ['rottentomatoes', 'Rotten Tomatoes'],
+      ['metacritic',     'Metacritic'],
+    ];
+
+    /* Valid min-score values per review platform */
+    const THRESHOLDS = {
+      imdb:           [5, 6, 7, 8],
+      rottentomatoes: [50, 60, 70, 80],
+      metacritic:     [50, 60, 70, 80],
+    };
+
+    /* Inline SVG logos so no external icon font is needed */
+    const PROV_ICON = {
+      imdb: `<svg width="32" height="16" viewBox="0 0 575 289.83"><path d="M575 24.91C573.44 12.15 563.97 1.98 551.91 0C499.05 0 76.18 0 23.32 0C10.11 2.17 0 14.16 0 28.61C0 51.84 0 237.64 0 260.86C0 276.86 12.37 289.83 27.64 289.83C79.63 289.83 495.6 289.83 547.59 289.83C561.65 289.83 573.26 278.82 575 264.57C575 216.64 575 48.87 575 24.91Z" fill="#f6c700"/><path d="M69.35 58.24L114.98 58.24L114.98 233.89L69.35 233.89L69.35 58.24Z" fill="#000"/><path d="M201.2 139.15C197.28 112.38 195.1 97.5 194.67 94.53C192.76 80.2 190.94 67.73 189.2 57.09C185.25 57.09 165.54 57.09 130.04 57.09L130.04 232.74L170.01 232.74L170.15 116.76L186.97 232.74L215.44 232.74L231.39 114.18L231.54 232.74L271.38 232.74L271.38 57.09L211.77 57.09L201.2 139.15Z" fill="#000"/><path d="M346.71 93.63C347.21 95.87 347.47 100.95 347.47 108.89C347.47 115.7 347.47 170.18 347.47 176.99C347.47 188.68 346.71 195.84 345.2 198.48C343.68 201.12 339.64 202.43 333.09 202.43C333.09 190.9 333.09 98.66 333.09 87.13C338.06 87.13 341.45 87.66 343.25 88.7C345.05 89.75 346.21 91.39 346.71 93.63ZM367.32 230.95C372.75 229.76 377.31 227.66 381.01 224.67C384.7 221.67 387.29 217.52 388.77 212.21C390.26 206.91 391.14 196.38 391.14 180.63C391.14 174.47 391.14 125.12 391.14 118.95C391.14 102.33 390.49 91.19 389.48 85.53C388.46 79.86 385.93 74.71 381.88 70.09C377.82 65.47 371.9 62.15 364.12 60.13C356.33 58.11 343.63 57.09 321.54 57.09C319.27 57.09 307.93 57.09 287.5 57.09L287.5 232.74L342.78 232.74C355.52 232.34 363.7 231.75 367.32 230.95Z" fill="#000"/><path d="M464.76 204.7C463.92 206.93 460.24 208.06 457.46 208.06C454.74 208.06 452.93 206.98 452.01 204.81C451.09 202.65 450.64 197.72 450.64 190C450.64 185.36 450.64 148.22 450.64 143.58C450.64 135.58 451.04 130.59 451.85 128.6C452.65 126.63 454.41 125.63 457.13 125.63C459.91 125.63 463.64 126.76 464.6 129.03C465.55 131.3 466.03 136.15 466.03 143.58C466.03 146.58 466.03 161.58 466.03 188.59C465.74 197.84 465.32 203.21 464.76 204.7ZM406.68 231.21L447.76 231.21C449.47 224.5 450.41 220.77 450.6 220.02C454.32 224.52 458.41 227.9 462.9 230.14C467.37 232.39 474.06 233.51 479.24 233.51C486.45 233.51 492.67 231.62 497.92 227.83C503.16 224.05 506.5 219.57 507.92 214.42C509.34 209.26 510.05 201.42 510.05 190.88C510.05 185.95 510.05 146.53 510.05 141.6C510.05 131 509.81 124.08 509.34 120.83C508.87 117.58 507.47 114.27 505.14 110.88C502.81 107.49 499.42 104.86 494.98 102.98C490.54 101.1 485.3 100.16 479.26 100.16C474.01 100.16 467.29 101.21 462.81 103.28C458.34 105.35 454.28 108.49 450.64 112.7C450.64 108.89 450.64 89.85 450.64 55.56L406.68 55.56L406.68 231.21Z" fill="#000"/></svg>`,
+      rottentomatoes: `<svg width="15" height="15" viewBox="0 0 138.75 141.25"><g fill="#f93208"><path d="m20.154 40.829c-28.149 27.622-13.657 61.011-5.734 71.931 35.254 41.954 92.792 25.339 111.89-5.9071 4.7608-8.2027 22.554-53.467-23.976-78.009z"/><path d="m39.613 39.265 4.7778-8.8607 28.406-5.0384 11.119 9.2082z"/></g><path d="m39.436 8.5696 8.9682-5.2826 6.7569 15.479c3.7925-6.3226 13.79-16.316 24.939-4.6684-4.7281 1.2636-7.5161 3.8553-7.7397 8.4768 15.145-4.1697 31.343 3.2127 33.539 9.0911-10.951-4.314-27.695 10.377-41.771 2.334 0.009 15.045-12.617 16.636-19.902 17.076 2.077-4.996 5.591-9.994 1.474-14.987-7.618 8.171-13.874 10.668-33.17 4.668 4.876-1.679 14.843-11.39 24.448-11.425-6.775-2.467-12.29-2.087-17.814-1.475 2.917-3.961 12.149-15.197 28.625-8.476z" fill="#02902e"/></svg>`,
+      metacritic: `<svg width="15" height="15" viewBox="0 0 40 40"><path d="M36.978 19.49a17.49 17.49 0 1 1 0-.021" fill="#000"/><path d="m17.209 32.937 3.41-3.41-6.567-6.567c-.276-.276-.576-.622-.737-1.014-.369-.783-.53-2.004.369-2.903 1.106-1.106 2.58-.645 4.009.784l6.313 6.313 3.41-3.41-6.59-6.59c-.276-.276-.599-.691-.76-1.037-.438-.898-.415-2.027.392-2.834 1.129-1.129 2.603-.714 4.24.922l6.128 6.129 3.41-3.41L27.6 9.274c-3.364-3.364-6.52-3.249-8.686-1.083-.83.83-1.337 1.705-1.59 2.696a6.71 6.71 0 0 0-.092 2.81l-.046.047c-1.66-.691-3.549-.277-5 1.175-1.936 1.935-1.866 3.986-1.636 5.184l-.07.07-1.681-1.36-2.95 2.949c1.037.945 2.282 2.097 3.687 3.502l7.673 7.673Z" fill="#F2F2F2"/><path d="M19.982 0A20 20 0 1 0 40 20v-.024A20 20 0 0 0 19.982 0Zm-.091 4.274A15.665 15.665 0 0 1 35.57 19.921v.018A15.665 15.665 0 1 1 19.89 4.274Z" fill="#FFBD3F"/></svg>`,
+    };
+
+
+    /* ════════════════════════════════════════════════
+       STATE
+    ════════════════════════════════════════════════ */
+
+    const state = {
+      theme:     'light',
+      provider:  'populaires',
+      threshold: 60,
+    };
+
+    /* In-memory fetch cache: url → parsed movie array */
+    const cache = {};
+
+    let movies      = [];
+    let animateNext = false; /* true → next renderGrid() staggers card entrances */
+
+
+    /* ════════════════════════════════════════════════
+       FILTER BAR
+    ════════════════════════════════════════════════ */
+
+    function buildFilterBar() {
+      const bar = document.getElementById('filterBar');
+
+      /* "Popular" and "All" rendered as standalone pill buttons */
+      const simplePills   = PROVIDERS.filter(([k]) => k === 'populaires' || k === 'tous');
+      /* IMDB, RT, Metacritic share a single segmented control */
+      const platformGroup = PROVIDERS.filter(([k]) => ['imdb', 'rottentomatoes', 'metacritic'].includes(k));
+
+      const pillsHtml = simplePills.map(([k, label]) => `
+        <button class="filter-chip ${state.provider === k ? 'active' : ''} rounded-full border"
+                style="border-color:var(--line)" data-prov="${k}">${label}</button>
+      `).join('');
+
+      const groupHtml = `
+        <div class="filter-group">
+          ${platformGroup.map(([k, label]) => `
+            <button class="filter-chip ${state.provider === k ? 'active' : ''}"
+                    title="${label}" data-prov="${k}">
+              ${PROV_ICON[k] || ''}
+              <span class="hidden sm:inline">${label}</span>
+            </button>
+          `).join('')}
+        </div>
+      `;
+
+      /* Threshold slider shown only for review-platform providers */
+      const threshDef  = THRESHOLDS[state.provider];
+      const threshHtml = threshDef ? `
+        <span style="width:1px;height:20px;background:var(--line)"></span>
+        ${buildThresholdHtml(threshDef)}
+      ` : '';
+
+      bar.innerHTML = `
+        <div class="flex flex-wrap items-center gap-3">
+          ${pillsHtml}
+          <span style="width:1px;height:20px;background:var(--line)"></span>
+          ${groupHtml}
+          ${threshHtml}
+        </div>
+        <span id="loadState" class="ml-auto text-xs" style="color:var(--muted)"></span>
+      `;
+
+      bar.querySelectorAll('[data-prov]').forEach(btn =>
+        btn.addEventListener('click', () => selectProvider(btn.dataset.prov))
+      );
+
+      if (threshDef) wireThreshold(bar, threshDef);
+    }
+
+    function buildThresholdHtml(threshDef) {
+      const min  = threshDef[0];
+      const max  = threshDef[threshDef.length - 1];
+      const step = threshDef[1] - threshDef[0];
+      const pct  = ((state.threshold - min) / (max - min)) * 100;
+
+      const ticksHtml = threshDef.map(v => `
+        <button class="thr-tick ${state.threshold === v ? 'on' : ''}" data-th="${v}">${v}</button>
+      `).join('');
+
+      return `
+        <div style="display:flex;flex-direction:column;gap:5px;width:160px">
+          <span style="font-size:11px;color:var(--muted)">min score</span>
+          <input type="range" id="thrRange"
+                 min="${min}" max="${max}" step="${step}" value="${state.threshold}"
+                 style="width:100%;background:linear-gradient(90deg,var(--accent) ${pct}%,var(--line) ${pct}%)">
+          <div style="display:flex;justify-content:space-between;padding:0 1px">${ticksHtml}</div>
+        </div>
+      `;
+    }
+
+    function wireThreshold(scope, threshDef) {
+      const min = threshDef[0];
+      const max = threshDef[threshDef.length - 1];
+
+      /* Tick buttons snap to a discrete value immediately */
+      scope.querySelectorAll('.thr-tick').forEach(btn =>
+        btn.addEventListener('click', () => setThreshold(+btn.dataset.th))
+      );
+
+      /* Range: update the fill colour while dragging, fetch on release */
+      const range = scope.querySelector('#thrRange');
+      if (!range) return;
+
+      range.addEventListener('input', () => {
+        const pct = ((range.value - min) / (max - min)) * 100;
+        range.style.background = `linear-gradient(90deg,var(--accent) ${pct}%,var(--line) ${pct}%)`;
+        scope.querySelectorAll('.thr-tick').forEach(t =>
+          t.classList.toggle('on', +t.dataset.th === +range.value)
+        );
+      });
+
+      range.addEventListener('change', () => setThreshold(+range.value));
+    }
+
+    function setThreshold(v) {
+      if (v === state.threshold) return;
+      state.threshold = v;
+      buildFilterBar(); /* re-render to sync active tick highlight */
+      fetchAndRender();
+    }
+
+    function selectProvider(key) {
+      if (key === state.provider) { fetchAndRender(); return; }
+      state.provider = key;
+      /* Reset threshold to a sensible default when switching platforms */
+      const t = THRESHOLDS[key];
+      if (t) state.threshold = key === 'imdb' ? 6 : 60;
+      buildFilterBar();
+      fetchAndRender();
+    }
+
+
+    /* ════════════════════════════════════════════════
+       DATA FETCHING
+    ════════════════════════════════════════════════ */
+
+    function endpointUrl() {
+      if (state.provider === 'populaires') return `${BASE}movies.json`;
+      if (state.provider === 'tous')       return `${BASE}all-movies.json`;
+      return `${BASE}movies-${state.provider}-min${state.threshold}.json`;
+    }
+
+    async function fetchAndRender() {
+      const url = endpointUrl();
+      document.getElementById('jsonLink').href = url;
+
+      const loadState = document.getElementById('loadState');
+
+      /* Serve from memory cache to avoid redundant network calls */
+      if (cache[url]) {
+        movies = cache[url];
+        animateNext = true;
+        renderGrid();
+        return;
+      }
+
+      if (loadState) loadState.textContent = 'Loading…';
+
+      try {
+        const res = await fetch(url, { cache: 'no-store' });
+        if (!res.ok) throw new Error('Network error');
+
+        const raw    = await res.json();
+        const parsed = raw
+          .map(m => ({
+            title:      m.title,
+            /* normalise http → https so mixed-content is never blocked */
+            poster_url: (m.poster_url || m.poster || '').replace(/^http:\/\//, 'https://') || null,
+          }))
+          .filter(m => m.title);
+
+        if (!parsed.length) throw new Error('Empty response');
+        cache[url] = parsed;
+        movies     = parsed;
+        if (loadState) loadState.textContent = '';
+      } catch {
+        movies = [];
+        if (loadState) loadState.textContent = 'Source unavailable';
+      }
+
+      animateNext = true;
+      renderGrid();
+    }
+
+
+    /* ════════════════════════════════════════════════
+       GRID RENDERING
+    ════════════════════════════════════════════════ */
+
+    /* Minimal HTML escaping for user-controlled strings */
+    function esc(s) {
+      return (s || '').replace(/[&<>"]/g,
+        c => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;' }[c])
+      );
+    }
+
+    function renderGrid() {
+      const grid  = document.getElementById('grid');
+      const empty = document.getElementById('emptyNote');
+
+      document.getElementById('countLabel').textContent = movies.length;
+
+      if (!movies.length) {
+        grid.innerHTML   = '';
+        empty.textContent = state.provider === 'populaires'
+          ? 'No movies to display.'
+          : 'No movies for this source — try another threshold.';
+        empty.classList.remove('hidden');
+        return;
+      }
+
+      empty.classList.add('hidden');
+
+      grid.innerHTML = movies.map((m, i) => {
+        /* Diagonal stripe placeholder when no poster image is available */
+        const imgHtml = m.poster_url
+          ? `<img loading="lazy" src="${m.poster_url}" alt="${esc(m.title)}"
+                  onerror="this.style.display='none';this.parentElement.classList.add('stripe')">`
+          : `<div class="absolute inset-0 stripe flex items-center justify-center p-3 text-center">
+               <span style="font-size:11px;font-family:'Space Grotesk',system-ui;
+                            text-transform:uppercase;letter-spacing:.05em;color:var(--muted)">
+                 ${esc(m.title)}
+               </span>
+             </div>`;
+
+        /* Stagger entrance delays up to 520 ms so large grids feel fluid */
+        const delay = animateNext ? `animation-delay:${Math.min(i * 28, 520)}ms` : '';
+
+        return `
+          <a href="https://www.imdb.com/find/?q=${encodeURIComponent(m.title)}"
+             target="_blank"
+             class="block ${animateNext ? 'anim' : ''}"
+             style="${delay}">
+            <div class="poster">
+              ${imgHtml}
+              <div class="overlay"><span>${esc(m.title)}</span></div>
+            </div>
+          </a>
+        `;
+      }).join('');
+
+      animateNext = false;
+    }
+
+    /* Re-trigger card entrances when the user returns to a hidden tab
+       (CSS animations pause while the tab is not visible) */
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) return;
+      document.querySelectorAll('#grid a').forEach((el, i) => {
+        el.classList.remove('anim');
+        void el.offsetWidth; /* force reflow so the animation restarts cleanly */
+        el.style.animationDelay = `${Math.min(i * 28, 520)}ms`;
+        el.classList.add('anim');
+      });
+    });
+
+
+    /* ════════════════════════════════════════════════
+       THEME TOGGLE
+    ════════════════════════════════════════════════ */
+
+    const ICON_MOON = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>`;
+    const ICON_SUN  = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>`;
+
+    const themeBtn = document.getElementById('themeToggle');
+
+    function applyTheme() {
+      document.documentElement.classList.toggle('dark', state.theme === 'dark');
+      themeBtn.innerHTML = state.theme === 'dark' ? ICON_SUN : ICON_MOON;
+    }
+
+    themeBtn.addEventListener('click', () => {
+      state.theme = state.theme === 'dark' ? 'light' : 'dark';
+      applyTheme();
+    });
+
+
+    /* ════════════════════════════════════════════════
+       BOOT
+    ════════════════════════════════════════════════ */
+
+    /* Random accent colour refreshed on every page load */
+    document.documentElement.style.setProperty(
+      '--accent', ACCENTS[Math.floor(Math.random() * ACCENTS.length)]
+    );
+
+    applyTheme();
+    buildFilterBar();
+    fetchAndRender();
+  </script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
         </span>
       </span>
       <span class="dropdown" style="float:right;margin-left:5px">
-        <a class="button dropdown-btn"><img src="https://www.google.com/s2/favicons?domain=rottentomatoes.com&sz=16" width="16" height="16" style="vertical-align:middle;margin-right:4px">Rotten Tomatoes</a>
+        <a class="button dropdown-btn"><img src="https://www.rottentomatoes.com/assets/pizza-pie/images/icons/tomatometer/tomatometer-fresh.149b5e8adc3.svg" width="16" height="16" style="vertical-align:middle;margin-right:4px">Rotten Tomatoes</a>
         <span class="dropdown-content">
           <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min50.json">Min 50</a>
           <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min60.json">Min 60</a>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       style="background:var(--bg);color:var(--fg)">
 
   <!-- ── Header ──────────────────────────────────────── -->
-  <header class="mx-auto px-5 sm:px-8" class="max-w-[1280px]">
+  <header class="container mx-auto px-4 sm:px-6 lg:px-8">
 
     <!-- Title row -->
     <div class="pt-10 sm:pt-16 pb-2 flex items-start justify-between gap-4">
@@ -85,14 +85,14 @@
 
 
   <!-- ── Movie grid ───────────────────────────────────── -->
-  <main class="mx-auto px-5 sm:px-8 pb-24" class="max-w-[1280px]">
+  <main class="container mx-auto px-4 sm:px-6 lg:px-8 pb-24">
     <div id="grid" class="grid-movies"></div>
     <p id="emptyNote" class="hidden text-center py-20 text-sm" style="color:var(--muted)"></p>
   </main>
 
 
   <!-- ── Footer ──────────────────────────────────────── -->
-  <footer class="mx-auto px-5 sm:px-8 pb-16 text-xs" style="max-width:var(--maxw);color:var(--muted)">
+  <footer class="container mx-auto px-4 sm:px-6 lg:px-8 pb-16 text-xs" style="color:var(--muted)">
     Data via
     <a href="https://movies.stevenlu.com" target="_blank" rel="noopener" class="underline">
       movies.stevenlu.com

--- a/index.html
+++ b/index.html
@@ -118,6 +118,19 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/3.0.3/handlebars.min.js"></script>
   <script type="text/javascript">
     $(document).ready(function() {
+      $('.dropdown-btn').on('click', function(e) {
+        e.preventDefault();
+        var $parent = $(this).parent('.dropdown');
+        $('.dropdown').not($parent).removeClass('open');
+        $parent.toggleClass('open');
+      });
+
+      $(document).on('click', function(e) {
+        if (!$(e.target).closest('.dropdown').length) {
+          $('.dropdown').removeClass('open');
+        }
+      });
+
       var posterTemplate = Handlebars.compile($('#poster-template').html());
       var movies = $.get('https://popular-movies-data.stevenlu.com/movies.json', function(data) {
         var currentRow, i;

--- a/index.html
+++ b/index.html
@@ -1,165 +1,271 @@
-
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="">
 <head>
-  <meta http-equiv="Content-Type" content="text/html" charset="utf-8">
+  <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="An algorithmic list of movies that look popular by a numeric heuristic">
-
   <title>Popular Movies</title>
 
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css" rel="stylesheet">
+  <!-- Utility CSS — replaces Skeleton 2.0 -->
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+
+  <!-- Fonts: Space Grotesk (headings) + DM Mono (labels) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <style>
+    /* ── Design tokens ────────────────────────────── */
+    :root {
+      --accent:  #3b82f6;
+      --bg:      #ffffff;
+      --fg:      #0a0a0a;
+      --muted:   #6b7280;
+      --card:    #ffffff;
+      --line:    #e7e7e7;
+      --shadow:  0 1px 3px rgba(0,0,0,.08);
+      --radius:  10px;
+      --gap:     20px;
+      --cols:    5;
+      --ratio:   2/3;
+      --maxw:    1280px;
+    }
+
+    /* Dark mode overrides */
+    html.dark {
+      --bg:     #0b0b0c;
+      --fg:     #f4f4f5;
+      --muted:  #8a8a92;
+      --card:   #141416;
+      --line:   #26262a;
+      --shadow: 0 1px 3px rgba(0,0,0,.5);
+    }
+
+    /* Smooth theme crossfade */
     body {
-      font-family: 'Open Sans', sans-serif;
-      padding-top: 15px;
+      background: var(--bg);
+      color: var(--fg);
+      font-family: system-ui, -apple-system, sans-serif;
+      transition: background .35s ease, color .35s ease;
     }
 
+    /* ── Poster grid ──────────────────────────────── */
+    .grid-movies {
+      display: grid;
+      grid-template-columns: repeat(var(--cols), minmax(0, 1fr));
+      gap: var(--gap);
+    }
+
+    /* ── Poster card ──────────────────────────────── */
     .poster {
-      margin-bottom: 25px;
-      text-align: center;
-    }
-
-    .poster a {
-      display: block;
+      aspect-ratio: var(--ratio);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: var(--card);
+      box-shadow: var(--shadow);
+      position: relative;
+      transition: transform .35s cubic-bezier(.2,.7,.2,1),
+                  box-shadow .35s ease,
+                  outline-color .2s ease;
+      outline: 1.5px solid transparent;
+      outline-offset: 2px;
     }
 
     .poster img {
-      border-radius: 5px;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+      transition: transform .45s cubic-bezier(.2,.7,.2,1);
     }
 
-    .dropdown {
-      position: relative;
-      display: inline-block;
+    /* Perspective tilt on hover */
+    .poster:hover {
+      transform: perspective(800px) rotateX(6deg) translateY(-4px);
+      box-shadow: 0 18px 40px rgba(0,0,0,.22);
     }
 
-    .dropdown-btn {
+    /* ── Title overlay (fades in on hover) ───────── */
+    .overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: flex-end;
+      padding: 12px;
+      background: linear-gradient(to top, rgba(0,0,0,.78), transparent 55%);
+      opacity: 0;
+      transition: opacity .3s ease;
+    }
+    .poster:hover .overlay { opacity: 1; }
+    .overlay span { color: #fff; font-weight: 600; font-size: 13px; line-height: 1.25; }
+
+    /* Striped placeholder for movies with no poster image */
+    .stripe {
+      background-image: repeating-linear-gradient(
+        45deg, var(--line) 0 8px, transparent 8px 16px
+      );
+    }
+
+    /* ── Card entrance animation ──────────────────── */
+    @keyframes cardIn {
+      from { opacity: 0; transform: translateY(12px) scale(.985); }
+      to   { opacity: 1; transform: none; }
+    }
+    .anim { animation: cardIn .5s cubic-bezier(.2,.7,.2,1) both; }
+
+    /* ── Filter bar — segmented button group ─────── */
+    .filter-group {
+      display: inline-flex;
+      align-items: stretch;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      overflow: hidden;
+    }
+
+    .filter-chip {
+      height: 32px;
+      padding: 0 14px;
+      font-size: 12.5px;
+      background: var(--card);
+      color: var(--fg);
+      border: 0;
+      border-left: 1px solid var(--line);
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      white-space: nowrap;
+      transition: background .15s, color .15s;
+    }
+    .filter-chip:first-child { border-left: 0; }
+
+    /* Active state: soft accent tint */
+    .filter-chip.active {
+      background: color-mix(in srgb, var(--accent) 16%, transparent);
+      color: var(--accent);
+      font-weight: 600;
+    }
+
+    /* ── Threshold range slider ───────────────────── */
+    input[type=range] {
+      -webkit-appearance: none;
+      appearance: none;
+      height: 4px;
+      border-radius: 99px;
+      background: var(--line); /* fill gradient set inline */
+    }
+    input[type=range]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 15px;
+      height: 15px;
+      border-radius: 50%;
+      background: var(--accent);
+      border: 2px solid #fff;
+      box-shadow: 0 1px 3px rgba(0,0,0,.25);
       cursor: pointer;
     }
 
-    .dropdown-content {
-      display: none;
-      position: absolute;
-      right: 0;
-      background: #fff;
-      border: 1px solid #ddd;
-      box-shadow: 0 2px 4px rgba(0,0,0,.1);
-      z-index: 10;
-      min-width: 120px;
+    /* Tick labels below the slider */
+    .thr-tick {
+      background: none;
+      border: 0;
+      cursor: pointer;
+      font-size: 11px;
+      color: var(--muted);
+      padding: 0;
+      transition: color .15s;
+      font-variant-numeric: tabular-nums;
     }
+    .thr-tick.on { color: var(--accent); font-weight: 700; }
 
-    .dropdown-content a {
-      display: block;
-      padding: 8px 15px;
-      color: #333;
-      text-decoration: none;
-      white-space: nowrap;
-    }
-
-    .dropdown-content a:hover {
-      background: #f5f5f5;
-    }
-
-    .dropdown.open .dropdown-content {
-      display: block;
-    }
+    /* ── Responsive column count ──────────────────── */
+    @media (max-width: 1024px) { :root { --cols: 4; } }
+    @media (max-width:  768px) { :root { --cols: 3; } }
+    @media (max-width:  480px) { :root { --cols: 2; } }
   </style>
 </head>
+
 <body>
-  <div class="container">
-    <h2>Popular Movies</h2>
-    <h4>
-      An algorithmic list of movies that look popular by a numeric heuristic.
-    </h4>
-    <p>
-      <a class="button button-primary" href="https://s3.amazonaws.com/popular-movies/movies.json">JSON List</a>
-      <a class="button" href="https://github.com/sjlu/popular-movies" target="_blank">GitHub</a>
 
-      <span class="dropdown" style="float:right;margin-left:5px">
-        <a class="button dropdown-btn"><img src="https://www.google.com/s2/favicons?domain=metacritic.com&sz=16" width="16" height="16" style="vertical-align:middle;margin-right:4px">Metacritic</a>
-        <span class="dropdown-content">
-          <a href="https://popular-movies-data.stevenlu.com/movies-metacritic-min50.json">Min 50</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-metacritic-min60.json">Min 60</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-metacritic-min70.json">Min 70</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-metacritic-min80.json">Min 80</a>
-        </span>
-      </span>
-      <span class="dropdown" style="float:right;margin-left:5px">
-        <a class="button dropdown-btn"><img src="https://www.rottentomatoes.com/assets/pizza-pie/images/icons/tomatometer/tomatometer-fresh.149b5e8adc3.svg" width="16" height="16" style="vertical-align:middle;margin-right:4px">Rotten Tomatoes</a>
-        <span class="dropdown-content">
-          <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min50.json">Min 50</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min60.json">Min 60</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min70.json">Min 70</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-rottentomatoes-min80.json">Min 80</a>
-        </span>
-      </span>
-      <span class="dropdown" style="float:right;margin-left:5px">
-        <a class="button dropdown-btn"><img src="https://www.google.com/s2/favicons?domain=imdb.com&sz=16" width="16" height="16" style="vertical-align:middle;margin-right:4px">IMDB</a>
-        <span class="dropdown-content">
-          <a href="https://popular-movies-data.stevenlu.com/movies-imdb-min5.json">Min 5</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-imdb-min6.json">Min 6</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-imdb-min7.json">Min 7</a>
-          <a href="https://popular-movies-data.stevenlu.com/movies-imdb-min8.json">Min 8</a>
-        </span>
-      </span>
-    </p>
-    <hr />
-    <div id="posters" class="row">
+  <!-- ── Header ──────────────────────────────────── -->
+  <header class="mx-auto px-5 sm:px-8" style="max-width:var(--maxw)">
+
+    <div class="pt-10 sm:pt-16 pb-2 flex items-start justify-between gap-4">
+      <div>
+        <h1 class="font-bold tracking-tight"
+            style="font-family:'Space Grotesk',system-ui,sans-serif;
+                   font-size:clamp(30px,5vw,52px); line-height:1.02">
+          Popular Movies
+        </h1>
+        <p class="mt-3 text-[15px]" style="color:var(--muted); max-width:52ch">
+          An algorithmic list of movies that look popular by a numeric heuristic.
+        </p>
+      </div>
+
+      <!-- Dark/light toggle — icon injected by JS -->
+      <button id="themeToggle"
+              aria-label="Toggle dark mode"
+              class="shrink-0 inline-flex items-center justify-center rounded-full w-10 h-10 border transition"
+              style="border-color:var(--line); background:var(--card); color:var(--fg)">
+      </button>
     </div>
-  </div>
-  <script id="poster-template" type="text/x-handlebars-template">
-    <div class="poster four columns">
-      <a href="{{link}}"><img src="{{url}}" class="u-max-full-width" /></a>
+
+    <!-- Source links + live movie count badge -->
+    <div class="flex flex-wrap items-center gap-2 mt-5 mb-7">
+      <!-- href updated dynamically whenever the active filter changes -->
+      <a id="jsonLink"
+         href="https://popular-movies-data.stevenlu.com/movies.json"
+         target="_blank"
+         class="text-xs font-medium px-3 h-8 inline-flex items-center gap-1.5 rounded-full text-white"
+         style="background:var(--accent)">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+             stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M8 3H7a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2 2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h1"/>
+          <path d="M16 3h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2 2 2 0 0 0-2 2v4a2 2 0 0 1-2 2h-1"/>
+        </svg>
+        JSON
+      </a>
+
+      <a href="https://github.com/sjlu/popular-movies"
+         target="_blank"
+         class="text-xs font-medium px-3 h-8 inline-flex items-center gap-1.5 rounded-full border"
+         style="border-color:var(--line); background:var(--card)">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+                   0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13
+                   -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66
+                   .07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15
+                   -.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0
+                   1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82
+                   1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01
+                   1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        GitHub
+      </a>
+
+      <span class="grow"></span>
+
+      <span class="text-xs px-3 h-8 inline-flex items-center rounded-full border"
+            style="border-color:var(--line); background:var(--card); color:var(--muted)">
+        <span id="countLabel">—</span>&nbsp;movies
+      </span>
     </div>
-  </script>
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/3.0.3/handlebars.min.js"></script>
-  <script type="text/javascript">
-    $(document).ready(function() {
-      $('.dropdown-btn').on('click', function(e) {
-        e.preventDefault();
-        var $parent = $(this).parent('.dropdown');
-        $('.dropdown').not($parent).removeClass('open');
-        $parent.toggleClass('open');
-      });
 
-      $(document).on('click', function(e) {
-        if (!$(e.target).closest('.dropdown').length) {
-          $('.dropdown').removeClass('open');
-        }
-      });
+    <!-- Filter bar — built and wired by JS -->
+    <div id="filterBar" class="flex flex-wrap items-center gap-3 mb-7"></div>
 
-      var posterTemplate = Handlebars.compile($('#poster-template').html());
+  </header>
 
-      function loadMovies(url) {
-        $('#posters').empty();
-        $.get(url, function(data) {
-          var currentRow, i;
-          for (i = 0; i < data.length; i++) {
-            var movie = data[i];
-            if (!(i % 3)) {
-              $('#posters').append(currentRow);
-              currentRow = $('<div class="row">');
-            }
-            currentRow.append(posterTemplate({
-              url: movie.poster_url,
-              link: "http://www.imdb.com/title/" + movie.imdb_id + "/"
-            }));
-          }
-          $('#posters').append(currentRow);
-        });
-      }
+  <!-- ── Movie grid ───────────────────────────────── -->
+  <main class="mx-auto px-5 sm:px-8 pb-24" style="max-width:var(--maxw)">
+    <div id="grid" class="grid-movies"></div>
+    <p id="emptyNote" class="hidden text-center py-20 text-sm" style="color:var(--muted)"></p>
+  </main>
 
-      $('.dropdown-content a').on('click', function(e) {
-        e.preventDefault();
-        loadMovies($(this).attr('href'));
-        $('.dropdown').removeClass('open');
-      });
+  <footer class="mx-auto px-5 sm:px-8 pb-16 text-xs" style="max-width:var(--maxw); color:var(--muted)">
+    Data via <a href="https://movies.stevenlu.com" target="_blank" class="underline">movies.stevenlu.com</a>.
+    Original concept by Steven Lu.
+  </footer>
 
-      loadMovies('https://popular-movies-data.stevenlu.com/movies.json');
-    });
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -91,14 +91,6 @@
   </main>
 
 
-  <!-- ── Footer ──────────────────────────────────────── -->
-  <footer class="container mx-auto px-4 sm:px-6 lg:px-8 pb-16 text-xs" style="color:var(--muted)">
-    Data via
-    <a href="https://movies.stevenlu.com" target="_blank" rel="noopener" class="underline">
-      movies.stevenlu.com
-    </a>.
-    Original concept by Steven Lu.
-  </footer>
 
 
   <!-- All logic in a separate file — no inline scripts -->

--- a/index.html
+++ b/index.html
@@ -132,24 +132,33 @@
       });
 
       var posterTemplate = Handlebars.compile($('#poster-template').html());
-      var movies = $.get('https://popular-movies-data.stevenlu.com/movies.json', function(data) {
-        var currentRow, i;
-        for (i = 0; i < data.length; i++) {
-          var movie = data[i];
 
-          if (!(i % 3)) {
-            $('#posters').append(currentRow);
-            currentRow = $('<div class="row">');
+      function loadMovies(url) {
+        $('#posters').empty();
+        $.get(url, function(data) {
+          var currentRow, i;
+          for (i = 0; i < data.length; i++) {
+            var movie = data[i];
+            if (!(i % 3)) {
+              $('#posters').append(currentRow);
+              currentRow = $('<div class="row">');
+            }
+            currentRow.append(posterTemplate({
+              url: movie.poster_url,
+              link: "http://www.imdb.com/title/" + movie.imdb_id + "/"
+            }));
           }
+          $('#posters').append(currentRow);
+        });
+      }
 
-          currentRow.append(posterTemplate({
-            url: movie.poster_url,
-            link: "http://www.imdb.com/title/" + movie.imdb_id + "/"
-          }));
-        }
-
-        $('#posters').append(currentRow);
+      $('.dropdown-content a').on('click', function(e) {
+        e.preventDefault();
+        loadMovies($(this).attr('href'));
+        $('.dropdown').removeClass('open');
       });
+
+      loadMovies('https://popular-movies-data.stevenlu.com/movies.json');
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,42 @@
     .poster img {
       border-radius: 5px;
     }
+
+    .dropdown {
+      position: relative;
+      display: inline-block;
+    }
+
+    .dropdown-btn {
+      cursor: pointer;
+    }
+
+    .dropdown-content {
+      display: none;
+      position: absolute;
+      right: 0;
+      background: #fff;
+      border: 1px solid #ddd;
+      box-shadow: 0 2px 4px rgba(0,0,0,.1);
+      z-index: 10;
+      min-width: 120px;
+    }
+
+    .dropdown-content a {
+      display: block;
+      padding: 8px 15px;
+      color: #333;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    .dropdown-content a:hover {
+      background: #f5f5f5;
+    }
+
+    .dropdown.open .dropdown-content {
+      display: block;
+    }
   </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       style="background:var(--bg);color:var(--fg)">
 
   <!-- ── Header ──────────────────────────────────────── -->
-  <header class="container mx-auto px-4 sm:px-6 lg:px-8">
+  <header class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
 
     <!-- Title row -->
     <div class="pt-10 sm:pt-16 pb-2 flex items-start justify-between gap-4">
@@ -85,7 +85,7 @@
 
 
   <!-- ── Movie grid ───────────────────────────────────── -->
-  <main class="container mx-auto px-4 sm:px-6 lg:px-8 pb-24">
+  <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
     <div id="grid" class="grid-movies"></div>
     <p id="emptyNote" class="hidden text-center py-20 text-sm" style="color:var(--muted)"></p>
   </main>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
   <!-- Only external dependency: Tailwind CSS utility classes -->
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 
+  <!-- Custom breakpoints: xs = 480px (aligns with the 2-column grid breakpoint in styles.css) -->
+  <style type="text/tailwindcss">
+    @theme {
+      --breakpoint-xs: 480px;
+    }
+  </style>
+
   <!-- Custom properties, animations, and effects Tailwind can't express -->
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -1,225 +1,56 @@
 <!DOCTYPE html>
-<html lang="en" class="">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="An algorithmic list of movies that look popular by a numeric heuristic">
   <title>Popular Movies</title>
 
-  <!-- Utility CSS — replaces Skeleton 2.0 -->
+  <!-- Only external dependency: Tailwind CSS utility classes -->
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 
-  <!-- Fonts: Space Grotesk (headings) + DM Mono (labels) -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
-
-  <style>
-    /* ── Design tokens ────────────────────────────── */
-    :root {
-      --accent:  #3b82f6;
-      --bg:      #ffffff;
-      --fg:      #0a0a0a;
-      --muted:   #6b7280;
-      --card:    #ffffff;
-      --line:    #e7e7e7;
-      --shadow:  0 1px 3px rgba(0,0,0,.08);
-      --radius:  10px;
-      --gap:     20px;
-      --cols:    5;
-      --ratio:   2/3;
-      --maxw:    1280px;
-    }
-
-    /* Dark mode overrides */
-    html.dark {
-      --bg:     #0b0b0c;
-      --fg:     #f4f4f5;
-      --muted:  #8a8a92;
-      --card:   #141416;
-      --line:   #26262a;
-      --shadow: 0 1px 3px rgba(0,0,0,.5);
-    }
-
-    /* Smooth theme crossfade */
-    body {
-      background: var(--bg);
-      color: var(--fg);
-      font-family: system-ui, -apple-system, sans-serif;
-      transition: background .35s ease, color .35s ease;
-    }
-
-    /* ── Poster grid ──────────────────────────────── */
-    .grid-movies {
-      display: grid;
-      grid-template-columns: repeat(var(--cols), minmax(0, 1fr));
-      gap: var(--gap);
-    }
-
-    /* ── Poster card ──────────────────────────────── */
-    .poster {
-      aspect-ratio: var(--ratio);
-      border-radius: var(--radius);
-      overflow: hidden;
-      background: var(--card);
-      box-shadow: var(--shadow);
-      position: relative;
-      transition: transform .35s cubic-bezier(.2,.7,.2,1),
-                  box-shadow .35s ease,
-                  outline-color .2s ease;
-      outline: 1.5px solid transparent;
-      outline-offset: 2px;
-    }
-
-    .poster img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-      transition: transform .45s cubic-bezier(.2,.7,.2,1);
-    }
-
-    /* Perspective tilt on hover */
-    .poster:hover {
-      transform: perspective(800px) rotateX(6deg) translateY(-4px);
-      box-shadow: 0 18px 40px rgba(0,0,0,.22);
-    }
-
-    /* ── Title overlay (fades in on hover) ───────── */
-    .overlay {
-      position: absolute;
-      inset: 0;
-      display: flex;
-      align-items: flex-end;
-      padding: 12px;
-      background: linear-gradient(to top, rgba(0,0,0,.78), transparent 55%);
-      opacity: 0;
-      transition: opacity .3s ease;
-    }
-    .poster:hover .overlay { opacity: 1; }
-    .overlay span { color: #fff; font-weight: 600; font-size: 13px; line-height: 1.25; }
-
-    /* Striped placeholder for movies with no poster image */
-    .stripe {
-      background-image: repeating-linear-gradient(
-        45deg, var(--line) 0 8px, transparent 8px 16px
-      );
-    }
-
-    /* ── Card entrance animation ──────────────────── */
-    @keyframes cardIn {
-      from { opacity: 0; transform: translateY(12px) scale(.985); }
-      to   { opacity: 1; transform: none; }
-    }
-    .anim { animation: cardIn .5s cubic-bezier(.2,.7,.2,1) both; }
-
-    /* ── Filter bar — segmented button group ─────── */
-    .filter-group {
-      display: inline-flex;
-      align-items: stretch;
-      border: 1px solid var(--line);
-      border-radius: 10px;
-      overflow: hidden;
-    }
-
-    .filter-chip {
-      height: 32px;
-      padding: 0 14px;
-      font-size: 12.5px;
-      background: var(--card);
-      color: var(--fg);
-      border: 0;
-      border-left: 1px solid var(--line);
-      cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      white-space: nowrap;
-      transition: background .15s, color .15s;
-    }
-    .filter-chip:first-child { border-left: 0; }
-
-    /* Active state: soft accent tint */
-    .filter-chip.active {
-      background: color-mix(in srgb, var(--accent) 16%, transparent);
-      color: var(--accent);
-      font-weight: 600;
-    }
-
-    /* ── Threshold range slider ───────────────────── */
-    input[type=range] {
-      -webkit-appearance: none;
-      appearance: none;
-      height: 4px;
-      border-radius: 99px;
-      background: var(--line); /* fill gradient set inline */
-    }
-    input[type=range]::-webkit-slider-thumb {
-      -webkit-appearance: none;
-      width: 15px;
-      height: 15px;
-      border-radius: 50%;
-      background: var(--accent);
-      border: 2px solid #fff;
-      box-shadow: 0 1px 3px rgba(0,0,0,.25);
-      cursor: pointer;
-    }
-
-    /* Tick labels below the slider */
-    .thr-tick {
-      background: none;
-      border: 0;
-      cursor: pointer;
-      font-size: 11px;
-      color: var(--muted);
-      padding: 0;
-      transition: color .15s;
-      font-variant-numeric: tabular-nums;
-    }
-    .thr-tick.on { color: var(--accent); font-weight: 700; }
-
-    /* ── Responsive column count ──────────────────── */
-    @media (max-width: 1024px) { :root { --cols: 4; } }
-    @media (max-width:  768px) { :root { --cols: 3; } }
-    @media (max-width:  480px) { :root { --cols: 2; } }
-  </style>
+  <!-- Custom properties, animations, and effects Tailwind can't express -->
+  <link rel="stylesheet" href="styles.css">
 </head>
 
-<body>
+<body class="font-sans antialiased min-h-screen transition-colors duration-300"
+      style="background:var(--bg);color:var(--fg)">
 
-  <!-- ── Header ──────────────────────────────────── -->
+  <!-- ── Header ──────────────────────────────────────── -->
   <header class="mx-auto px-5 sm:px-8" style="max-width:var(--maxw)">
 
+    <!-- Title row -->
     <div class="pt-10 sm:pt-16 pb-2 flex items-start justify-between gap-4">
       <div>
-        <h1 class="font-bold tracking-tight"
-            style="font-family:'Space Grotesk',system-ui,sans-serif;
-                   font-size:clamp(30px,5vw,52px); line-height:1.02">
+        <h1 class="font-bold tracking-tight leading-none"
+            style="font-size:clamp(30px,5vw,52px)">
           Popular Movies
         </h1>
-        <p class="mt-3 text-[15px]" style="color:var(--muted); max-width:52ch">
+        <p class="mt-3 text-[15px] max-w-[52ch]" style="color:var(--muted)">
           An algorithmic list of movies that look popular by a numeric heuristic.
         </p>
       </div>
 
-      <!-- Dark/light toggle — icon injected by JS -->
+      <!-- Dark / light toggle — icon injected by app.js -->
       <button id="themeToggle"
               aria-label="Toggle dark mode"
-              class="shrink-0 inline-flex items-center justify-center rounded-full w-10 h-10 border transition"
-              style="border-color:var(--line); background:var(--card); color:var(--fg)">
+              class="shrink-0 inline-flex items-center justify-center rounded-full w-10 h-10 border transition-colors"
+              style="border-color:var(--line);background:var(--card);color:var(--fg)">
       </button>
     </div>
 
-    <!-- Source links + live movie count badge -->
+    <!-- Source links + live count badge -->
     <div class="flex flex-wrap items-center gap-2 mt-5 mb-7">
-      <!-- href updated dynamically whenever the active filter changes -->
+
+      <!-- href is updated by app.js whenever the active filter changes -->
       <a id="jsonLink"
          href="https://popular-movies-data.stevenlu.com/movies.json"
-         target="_blank"
-         class="text-xs font-medium px-3 h-8 inline-flex items-center gap-1.5 rounded-full text-white"
+         target="_blank" rel="noopener"
+         class="text-xs font-medium px-3 h-8 inline-flex items-center gap-1.5 rounded-full text-white transition-opacity hover:opacity-90"
          style="background:var(--accent)">
+        <!-- JSON brackets icon -->
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-             stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+             stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M8 3H7a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2 2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h1"/>
           <path d="M16 3h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2 2 2 0 0 0-2 2v4a2 2 0 0 1-2 2h-1"/>
         </svg>
@@ -227,372 +58,56 @@
       </a>
 
       <a href="https://github.com/sjlu/popular-movies"
-         target="_blank"
-         class="text-xs font-medium px-3 h-8 inline-flex items-center gap-1.5 rounded-full border"
-         style="border-color:var(--line); background:var(--card)">
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+         target="_blank" rel="noopener"
+         class="text-xs font-medium px-3 h-8 inline-flex items-center gap-1.5 rounded-full border transition-colors hover:opacity-80"
+         style="border-color:var(--line);background:var(--card)">
+        <!-- GitHub mark -->
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
                    0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13
                    -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66
                    .07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15
                    -.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0
-                   1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82
-                   1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01
-                   1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+                   1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56
+                   .82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07
+                   -.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
         </svg>
         GitHub
       </a>
 
       <span class="grow"></span>
 
+      <!-- Movie count — updated live by app.js -->
       <span class="text-xs px-3 h-8 inline-flex items-center rounded-full border"
-            style="border-color:var(--line); background:var(--card); color:var(--muted)">
+            style="border-color:var(--line);background:var(--card);color:var(--muted)">
         <span id="countLabel">—</span>&nbsp;movies
       </span>
     </div>
 
-    <!-- Filter bar — built and wired by JS -->
+    <!-- Filter bar — built and wired entirely by app.js -->
     <div id="filterBar" class="flex flex-wrap items-center gap-3 mb-7"></div>
 
   </header>
 
-  <!-- ── Movie grid ───────────────────────────────── -->
+
+  <!-- ── Movie grid ───────────────────────────────────── -->
   <main class="mx-auto px-5 sm:px-8 pb-24" style="max-width:var(--maxw)">
     <div id="grid" class="grid-movies"></div>
     <p id="emptyNote" class="hidden text-center py-20 text-sm" style="color:var(--muted)"></p>
   </main>
 
-  <footer class="mx-auto px-5 sm:px-8 pb-16 text-xs" style="max-width:var(--maxw); color:var(--muted)">
-    Data via <a href="https://movies.stevenlu.com" target="_blank" class="underline">movies.stevenlu.com</a>.
+
+  <!-- ── Footer ──────────────────────────────────────── -->
+  <footer class="mx-auto px-5 sm:px-8 pb-16 text-xs" style="max-width:var(--maxw);color:var(--muted)">
+    Data via
+    <a href="https://movies.stevenlu.com" target="_blank" rel="noopener" class="underline">
+      movies.stevenlu.com
+    </a>.
     Original concept by Steven Lu.
   </footer>
 
 
-  <script>
-    /* ════════════════════════════════════════════════
-       CONFIGURATION
-    ════════════════════════════════════════════════ */
-
-    const BASE = 'https://popular-movies-data.stevenlu.com/';
-
-    /* Accent palette — one colour chosen at random on every page load */
-    const ACCENTS = ['#3b82f6','#ef4444','#f59e0b','#10b981','#8b5cf6','#ec4899','#0ea5e9','#e11d48','#14b8a6'];
-
-    /* Filter sources: [url key, display label] */
-    const PROVIDERS = [
-      ['populaires',     'Popular'],
-      ['tous',           'All'],
-      ['imdb',           'IMDB'],
-      ['rottentomatoes', 'Rotten Tomatoes'],
-      ['metacritic',     'Metacritic'],
-    ];
-
-    /* Valid min-score values per review platform */
-    const THRESHOLDS = {
-      imdb:           [5, 6, 7, 8],
-      rottentomatoes: [50, 60, 70, 80],
-      metacritic:     [50, 60, 70, 80],
-    };
-
-    /* Inline SVG logos so no external icon font is needed */
-    const PROV_ICON = {
-      imdb: `<svg width="32" height="16" viewBox="0 0 575 289.83"><path d="M575 24.91C573.44 12.15 563.97 1.98 551.91 0C499.05 0 76.18 0 23.32 0C10.11 2.17 0 14.16 0 28.61C0 51.84 0 237.64 0 260.86C0 276.86 12.37 289.83 27.64 289.83C79.63 289.83 495.6 289.83 547.59 289.83C561.65 289.83 573.26 278.82 575 264.57C575 216.64 575 48.87 575 24.91Z" fill="#f6c700"/><path d="M69.35 58.24L114.98 58.24L114.98 233.89L69.35 233.89L69.35 58.24Z" fill="#000"/><path d="M201.2 139.15C197.28 112.38 195.1 97.5 194.67 94.53C192.76 80.2 190.94 67.73 189.2 57.09C185.25 57.09 165.54 57.09 130.04 57.09L130.04 232.74L170.01 232.74L170.15 116.76L186.97 232.74L215.44 232.74L231.39 114.18L231.54 232.74L271.38 232.74L271.38 57.09L211.77 57.09L201.2 139.15Z" fill="#000"/><path d="M346.71 93.63C347.21 95.87 347.47 100.95 347.47 108.89C347.47 115.7 347.47 170.18 347.47 176.99C347.47 188.68 346.71 195.84 345.2 198.48C343.68 201.12 339.64 202.43 333.09 202.43C333.09 190.9 333.09 98.66 333.09 87.13C338.06 87.13 341.45 87.66 343.25 88.7C345.05 89.75 346.21 91.39 346.71 93.63ZM367.32 230.95C372.75 229.76 377.31 227.66 381.01 224.67C384.7 221.67 387.29 217.52 388.77 212.21C390.26 206.91 391.14 196.38 391.14 180.63C391.14 174.47 391.14 125.12 391.14 118.95C391.14 102.33 390.49 91.19 389.48 85.53C388.46 79.86 385.93 74.71 381.88 70.09C377.82 65.47 371.9 62.15 364.12 60.13C356.33 58.11 343.63 57.09 321.54 57.09C319.27 57.09 307.93 57.09 287.5 57.09L287.5 232.74L342.78 232.74C355.52 232.34 363.7 231.75 367.32 230.95Z" fill="#000"/><path d="M464.76 204.7C463.92 206.93 460.24 208.06 457.46 208.06C454.74 208.06 452.93 206.98 452.01 204.81C451.09 202.65 450.64 197.72 450.64 190C450.64 185.36 450.64 148.22 450.64 143.58C450.64 135.58 451.04 130.59 451.85 128.6C452.65 126.63 454.41 125.63 457.13 125.63C459.91 125.63 463.64 126.76 464.6 129.03C465.55 131.3 466.03 136.15 466.03 143.58C466.03 146.58 466.03 161.58 466.03 188.59C465.74 197.84 465.32 203.21 464.76 204.7ZM406.68 231.21L447.76 231.21C449.47 224.5 450.41 220.77 450.6 220.02C454.32 224.52 458.41 227.9 462.9 230.14C467.37 232.39 474.06 233.51 479.24 233.51C486.45 233.51 492.67 231.62 497.92 227.83C503.16 224.05 506.5 219.57 507.92 214.42C509.34 209.26 510.05 201.42 510.05 190.88C510.05 185.95 510.05 146.53 510.05 141.6C510.05 131 509.81 124.08 509.34 120.83C508.87 117.58 507.47 114.27 505.14 110.88C502.81 107.49 499.42 104.86 494.98 102.98C490.54 101.1 485.3 100.16 479.26 100.16C474.01 100.16 467.29 101.21 462.81 103.28C458.34 105.35 454.28 108.49 450.64 112.7C450.64 108.89 450.64 89.85 450.64 55.56L406.68 55.56L406.68 231.21Z" fill="#000"/></svg>`,
-      rottentomatoes: `<svg width="15" height="15" viewBox="0 0 138.75 141.25"><g fill="#f93208"><path d="m20.154 40.829c-28.149 27.622-13.657 61.011-5.734 71.931 35.254 41.954 92.792 25.339 111.89-5.9071 4.7608-8.2027 22.554-53.467-23.976-78.009z"/><path d="m39.613 39.265 4.7778-8.8607 28.406-5.0384 11.119 9.2082z"/></g><path d="m39.436 8.5696 8.9682-5.2826 6.7569 15.479c3.7925-6.3226 13.79-16.316 24.939-4.6684-4.7281 1.2636-7.5161 3.8553-7.7397 8.4768 15.145-4.1697 31.343 3.2127 33.539 9.0911-10.951-4.314-27.695 10.377-41.771 2.334 0.009 15.045-12.617 16.636-19.902 17.076 2.077-4.996 5.591-9.994 1.474-14.987-7.618 8.171-13.874 10.668-33.17 4.668 4.876-1.679 14.843-11.39 24.448-11.425-6.775-2.467-12.29-2.087-17.814-1.475 2.917-3.961 12.149-15.197 28.625-8.476z" fill="#02902e"/></svg>`,
-      metacritic: `<svg width="15" height="15" viewBox="0 0 40 40"><path d="M36.978 19.49a17.49 17.49 0 1 1 0-.021" fill="#000"/><path d="m17.209 32.937 3.41-3.41-6.567-6.567c-.276-.276-.576-.622-.737-1.014-.369-.783-.53-2.004.369-2.903 1.106-1.106 2.58-.645 4.009.784l6.313 6.313 3.41-3.41-6.59-6.59c-.276-.276-.599-.691-.76-1.037-.438-.898-.415-2.027.392-2.834 1.129-1.129 2.603-.714 4.24.922l6.128 6.129 3.41-3.41L27.6 9.274c-3.364-3.364-6.52-3.249-8.686-1.083-.83.83-1.337 1.705-1.59 2.696a6.71 6.71 0 0 0-.092 2.81l-.046.047c-1.66-.691-3.549-.277-5 1.175-1.936 1.935-1.866 3.986-1.636 5.184l-.07.07-1.681-1.36-2.95 2.949c1.037.945 2.282 2.097 3.687 3.502l7.673 7.673Z" fill="#F2F2F2"/><path d="M19.982 0A20 20 0 1 0 40 20v-.024A20 20 0 0 0 19.982 0Zm-.091 4.274A15.665 15.665 0 0 1 35.57 19.921v.018A15.665 15.665 0 1 1 19.89 4.274Z" fill="#FFBD3F"/></svg>`,
-    };
-
-
-    /* ════════════════════════════════════════════════
-       STATE
-    ════════════════════════════════════════════════ */
-
-    const state = {
-      theme:     'light',
-      provider:  'populaires',
-      threshold: 60,
-    };
-
-    /* In-memory fetch cache: url → parsed movie array */
-    const cache = {};
-
-    let movies      = [];
-    let animateNext = false; /* true → next renderGrid() staggers card entrances */
-
-
-    /* ════════════════════════════════════════════════
-       FILTER BAR
-    ════════════════════════════════════════════════ */
-
-    function buildFilterBar() {
-      const bar = document.getElementById('filterBar');
-
-      /* "Popular" and "All" rendered as standalone pill buttons */
-      const simplePills   = PROVIDERS.filter(([k]) => k === 'populaires' || k === 'tous');
-      /* IMDB, RT, Metacritic share a single segmented control */
-      const platformGroup = PROVIDERS.filter(([k]) => ['imdb', 'rottentomatoes', 'metacritic'].includes(k));
-
-      const pillsHtml = simplePills.map(([k, label]) => `
-        <button class="filter-chip ${state.provider === k ? 'active' : ''} rounded-full border"
-                style="border-color:var(--line)" data-prov="${k}">${label}</button>
-      `).join('');
-
-      const groupHtml = `
-        <div class="filter-group">
-          ${platformGroup.map(([k, label]) => `
-            <button class="filter-chip ${state.provider === k ? 'active' : ''}"
-                    title="${label}" data-prov="${k}">
-              ${PROV_ICON[k] || ''}
-              <span class="hidden sm:inline">${label}</span>
-            </button>
-          `).join('')}
-        </div>
-      `;
-
-      /* Threshold slider shown only for review-platform providers */
-      const threshDef  = THRESHOLDS[state.provider];
-      const threshHtml = threshDef ? `
-        <span style="width:1px;height:20px;background:var(--line)"></span>
-        ${buildThresholdHtml(threshDef)}
-      ` : '';
-
-      bar.innerHTML = `
-        <div class="flex flex-wrap items-center gap-3">
-          ${pillsHtml}
-          <span style="width:1px;height:20px;background:var(--line)"></span>
-          ${groupHtml}
-          ${threshHtml}
-        </div>
-        <span id="loadState" class="ml-auto text-xs" style="color:var(--muted)"></span>
-      `;
-
-      bar.querySelectorAll('[data-prov]').forEach(btn =>
-        btn.addEventListener('click', () => selectProvider(btn.dataset.prov))
-      );
-
-      if (threshDef) wireThreshold(bar, threshDef);
-    }
-
-    function buildThresholdHtml(threshDef) {
-      const min  = threshDef[0];
-      const max  = threshDef[threshDef.length - 1];
-      const step = threshDef[1] - threshDef[0];
-      const pct  = ((state.threshold - min) / (max - min)) * 100;
-
-      const ticksHtml = threshDef.map(v => `
-        <button class="thr-tick ${state.threshold === v ? 'on' : ''}" data-th="${v}">${v}</button>
-      `).join('');
-
-      return `
-        <div style="display:flex;flex-direction:column;gap:5px;width:160px">
-          <span style="font-size:11px;color:var(--muted)">min score</span>
-          <input type="range" id="thrRange"
-                 min="${min}" max="${max}" step="${step}" value="${state.threshold}"
-                 style="width:100%;background:linear-gradient(90deg,var(--accent) ${pct}%,var(--line) ${pct}%)">
-          <div style="display:flex;justify-content:space-between;padding:0 1px">${ticksHtml}</div>
-        </div>
-      `;
-    }
-
-    function wireThreshold(scope, threshDef) {
-      const min = threshDef[0];
-      const max = threshDef[threshDef.length - 1];
-
-      /* Tick buttons snap to a discrete value immediately */
-      scope.querySelectorAll('.thr-tick').forEach(btn =>
-        btn.addEventListener('click', () => setThreshold(+btn.dataset.th))
-      );
-
-      /* Range: update the fill colour while dragging, fetch on release */
-      const range = scope.querySelector('#thrRange');
-      if (!range) return;
-
-      range.addEventListener('input', () => {
-        const pct = ((range.value - min) / (max - min)) * 100;
-        range.style.background = `linear-gradient(90deg,var(--accent) ${pct}%,var(--line) ${pct}%)`;
-        scope.querySelectorAll('.thr-tick').forEach(t =>
-          t.classList.toggle('on', +t.dataset.th === +range.value)
-        );
-      });
-
-      range.addEventListener('change', () => setThreshold(+range.value));
-    }
-
-    function setThreshold(v) {
-      if (v === state.threshold) return;
-      state.threshold = v;
-      buildFilterBar(); /* re-render to sync active tick highlight */
-      fetchAndRender();
-    }
-
-    function selectProvider(key) {
-      if (key === state.provider) { fetchAndRender(); return; }
-      state.provider = key;
-      /* Reset threshold to a sensible default when switching platforms */
-      const t = THRESHOLDS[key];
-      if (t) state.threshold = key === 'imdb' ? 6 : 60;
-      buildFilterBar();
-      fetchAndRender();
-    }
-
-
-    /* ════════════════════════════════════════════════
-       DATA FETCHING
-    ════════════════════════════════════════════════ */
-
-    function endpointUrl() {
-      if (state.provider === 'populaires') return `${BASE}movies.json`;
-      if (state.provider === 'tous')       return `${BASE}all-movies.json`;
-      return `${BASE}movies-${state.provider}-min${state.threshold}.json`;
-    }
-
-    async function fetchAndRender() {
-      const url = endpointUrl();
-      document.getElementById('jsonLink').href = url;
-
-      const loadState = document.getElementById('loadState');
-
-      /* Serve from memory cache to avoid redundant network calls */
-      if (cache[url]) {
-        movies = cache[url];
-        animateNext = true;
-        renderGrid();
-        return;
-      }
-
-      if (loadState) loadState.textContent = 'Loading…';
-
-      try {
-        const res = await fetch(url, { cache: 'no-store' });
-        if (!res.ok) throw new Error('Network error');
-
-        const raw    = await res.json();
-        const parsed = raw
-          .map(m => ({
-            title:      m.title,
-            /* normalise http → https so mixed-content is never blocked */
-            poster_url: (m.poster_url || m.poster || '').replace(/^http:\/\//, 'https://') || null,
-          }))
-          .filter(m => m.title);
-
-        if (!parsed.length) throw new Error('Empty response');
-        cache[url] = parsed;
-        movies     = parsed;
-        if (loadState) loadState.textContent = '';
-      } catch {
-        movies = [];
-        if (loadState) loadState.textContent = 'Source unavailable';
-      }
-
-      animateNext = true;
-      renderGrid();
-    }
-
-
-    /* ════════════════════════════════════════════════
-       GRID RENDERING
-    ════════════════════════════════════════════════ */
-
-    /* Minimal HTML escaping for user-controlled strings */
-    function esc(s) {
-      return (s || '').replace(/[&<>"]/g,
-        c => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;' }[c])
-      );
-    }
-
-    function renderGrid() {
-      const grid  = document.getElementById('grid');
-      const empty = document.getElementById('emptyNote');
-
-      document.getElementById('countLabel').textContent = movies.length;
-
-      if (!movies.length) {
-        grid.innerHTML   = '';
-        empty.textContent = state.provider === 'populaires'
-          ? 'No movies to display.'
-          : 'No movies for this source — try another threshold.';
-        empty.classList.remove('hidden');
-        return;
-      }
-
-      empty.classList.add('hidden');
-
-      grid.innerHTML = movies.map((m, i) => {
-        /* Diagonal stripe placeholder when no poster image is available */
-        const imgHtml = m.poster_url
-          ? `<img loading="lazy" src="${m.poster_url}" alt="${esc(m.title)}"
-                  onerror="this.style.display='none';this.parentElement.classList.add('stripe')">`
-          : `<div class="absolute inset-0 stripe flex items-center justify-center p-3 text-center">
-               <span style="font-size:11px;font-family:'Space Grotesk',system-ui;
-                            text-transform:uppercase;letter-spacing:.05em;color:var(--muted)">
-                 ${esc(m.title)}
-               </span>
-             </div>`;
-
-        /* Stagger entrance delays up to 520 ms so large grids feel fluid */
-        const delay = animateNext ? `animation-delay:${Math.min(i * 28, 520)}ms` : '';
-
-        return `
-          <a href="https://www.imdb.com/find/?q=${encodeURIComponent(m.title)}"
-             target="_blank"
-             class="block ${animateNext ? 'anim' : ''}"
-             style="${delay}">
-            <div class="poster">
-              ${imgHtml}
-              <div class="overlay"><span>${esc(m.title)}</span></div>
-            </div>
-          </a>
-        `;
-      }).join('');
-
-      animateNext = false;
-    }
-
-    /* Re-trigger card entrances when the user returns to a hidden tab
-       (CSS animations pause while the tab is not visible) */
-    document.addEventListener('visibilitychange', () => {
-      if (document.hidden) return;
-      document.querySelectorAll('#grid a').forEach((el, i) => {
-        el.classList.remove('anim');
-        void el.offsetWidth; /* force reflow so the animation restarts cleanly */
-        el.style.animationDelay = `${Math.min(i * 28, 520)}ms`;
-        el.classList.add('anim');
-      });
-    });
-
-
-    /* ════════════════════════════════════════════════
-       THEME TOGGLE
-    ════════════════════════════════════════════════ */
-
-    const ICON_MOON = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>`;
-    const ICON_SUN  = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>`;
-
-    const themeBtn = document.getElementById('themeToggle');
-
-    function applyTheme() {
-      document.documentElement.classList.toggle('dark', state.theme === 'dark');
-      themeBtn.innerHTML = state.theme === 'dark' ? ICON_SUN : ICON_MOON;
-    }
-
-    themeBtn.addEventListener('click', () => {
-      state.theme = state.theme === 'dark' ? 'light' : 'dark';
-      applyTheme();
-    });
-
-
-    /* ════════════════════════════════════════════════
-       BOOT
-    ════════════════════════════════════════════════ */
-
-    /* Random accent colour refreshed on every page load */
-    document.documentElement.style.setProperty(
-      '--accent', ACCENTS[Math.floor(Math.random() * ACCENTS.length)]
-    );
-
-    applyTheme();
-    buildFilterBar();
-    fetchAndRender();
-  </script>
-
+  <!-- All logic in a separate file — no inline scripts -->
+  <script src="app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -76,12 +76,6 @@
       </a>
 
       <span class="grow"></span>
-
-      <!-- Movie count — updated live by app.js -->
-      <span class="text-xs px-3 h-8 inline-flex items-center rounded-full border"
-            style="border-color:var(--line);background:var(--card);color:var(--muted)">
-        <span id="countLabel">—</span>&nbsp;movies
-      </span>
     </div>
 
     <!-- Filter bar — built and wired entirely by app.js -->

--- a/styles.css
+++ b/styles.css
@@ -35,7 +35,7 @@ html.dark {
 
 @media (max-width: 1024px) { :root { --cols: 4; } }
 @media (max-width:  768px) { :root { --cols: 3; } }
-@media (max-width:  480px) { :root { --cols: 2; } }
+@media (max-width:  480px) { :root { --cols: 2; } } /* xs breakpoint */
 
 
 /* ── Poster card hover ──────────────────────────────────

--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,6 @@
   --line:   #e7e7e7;
   --radius: 10px;
   --cols:   5;
-  --maxw:   1280px;
 }
 
 /* Dark mode — swaps every token, no Tailwind dark: prefix needed */

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,122 @@
+/* ── Design tokens ──────────────────────────────────────
+   All colours and layout constants as CSS custom properties.
+   Tailwind's arbitrary-value syntax [var(--x)] references these.
+   ───────────────────────────────────────────────────── */
+:root {
+  --accent: #3b82f6;
+  --bg:     #ffffff;
+  --fg:     #0a0a0a;
+  --muted:  #6b7280;
+  --card:   #ffffff;
+  --line:   #e7e7e7;
+  --radius: 10px;
+  --cols:   5;
+  --maxw:   1280px;
+}
+
+/* Dark mode — swaps every token, no Tailwind dark: prefix needed */
+html.dark {
+  --bg:    #0b0b0c;
+  --fg:    #f4f4f5;
+  --muted: #8a8a92;
+  --card:  #141416;
+  --line:  #26262a;
+}
+
+
+/* ── Poster grid ────────────────────────────────────────
+   Column count is a CSS variable so JS can clamp it at runtime.
+   Tailwind can't express repeat(var(--cols), …) directly.
+   ───────────────────────────────────────────────────── */
+.grid-movies {
+  display: grid;
+  grid-template-columns: repeat(var(--cols), minmax(0, 1fr));
+  gap: 20px;
+}
+
+@media (max-width: 1024px) { :root { --cols: 4; } }
+@media (max-width:  768px) { :root { --cols: 3; } }
+@media (max-width:  480px) { :root { --cols: 2; } }
+
+
+/* ── Poster card hover ──────────────────────────────────
+   Perspective tilt can't be expressed with Tailwind utilities.
+   ───────────────────────────────────────────────────── */
+.poster {
+  transition: transform .35s cubic-bezier(.2,.7,.2,1), box-shadow .35s ease;
+}
+.poster:hover {
+  transform: perspective(800px) rotateX(6deg) translateY(-4px);
+  box-shadow: 0 18px 40px rgba(0,0,0,.22);
+}
+.poster img {
+  transition: transform .45s cubic-bezier(.2,.7,.2,1);
+}
+
+
+/* ── Title overlay ──────────────────────────────────────
+   Gradient-to-top + opacity toggle on parent hover.
+   ───────────────────────────────────────────────────── */
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: 12px;
+  background: linear-gradient(to top, rgba(0,0,0,.78), transparent 55%);
+  opacity: 0;
+  transition: opacity .3s ease;
+}
+.poster:hover .overlay { opacity: 1; }
+
+
+/* ── Striped placeholder ────────────────────────────────
+   Shown when a movie has no poster URL.
+   ───────────────────────────────────────────────────── */
+.stripe {
+  background-image: repeating-linear-gradient(
+    45deg, var(--line) 0 8px, transparent 8px 16px
+  );
+}
+
+
+/* ── Card entrance animation ────────────────────────────
+   Cards stagger in on first render and on tab return.
+   ───────────────────────────────────────────────────── */
+@keyframes cardIn {
+  from { opacity: 0; transform: translateY(12px) scale(.985); }
+  to   { opacity: 1; transform: none; }
+}
+.anim { animation: cardIn .5s cubic-bezier(.2,.7,.2,1) both; }
+
+
+/* ── Range input ────────────────────────────────────────
+   Browser defaults are inconsistent; Tailwind has no thumb utilities.
+   ───────────────────────────────────────────────────── */
+input[type=range] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 99px;
+  /* fill gradient is set inline by JS to reflect current value */
+  background: var(--line);
+}
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,.25);
+  cursor: pointer;
+}
+input[type=range]::-moz-range-thumb {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,.25);
+  cursor: pointer;
+}

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@
   --card:   #ffffff;
   --line:   #e7e7e7;
   --radius: 10px;
-  --cols:   5;
+  --cols:   4;
 }
 
 /* Dark mode — swaps every token, no Tailwind dark: prefix needed */


### PR DESCRIPTION
## What changed

A full visual redesign of the single-page app, split across three clean files.

<img width="1512" height="765" alt="Screenshot 2026-06-27 at 08 49 33" src="https://github.com/user-attachments/assets/8e50ab53-c110-4563-8264-ddfc1e1ec641" />

## File structure

| File | Role |
|---|---|
| `index.html` | Markup only — layout via Tailwind utility classes, no inline scripts |
| `styles.css` | Minimal custom CSS: design tokens, grid, animations, effects Tailwind can't express |
| `app.js` | All JavaScript — filter bar, data fetching, grid rendering, theme toggle |

**Only external dependency: `@tailwindcss/browser@4` CDN.** No fonts, no icon libraries, no jQuery, no Handlebars, no Skeleton.

## Commits

1. **Replace legacy deps with modern CSS design system and page structure**
   Drops jQuery 2.1, Handlebars 3.0, Skeleton 2.0 and Open Sans. Introduces CSS custom properties for every design token, a `html.dark` override block, the poster grid, hover tilt, overlay, stripe placeholder, and entrance animation.

2. **Add filter bar, data fetching, poster grid, and theme toggle**
   Provider chips (Popular/All as pills; IMDB/RT/Metacritic as a segmented group with inline SVGs), threshold slider, `fetch()`-based data loading with in-memory cache, staggered card animation, and dark/light toggle.

3. **Split into index.html / styles.css / app.js, maximise Tailwind**
   Moves all JS to `app.js`, all custom CSS to `styles.css`, and uses Tailwind utilities throughout the markup. Drops external fonts in favour of the system `font-sans` stack.

## What styles.css contains (and why)

Everything else lives in Tailwind — `styles.css` is only for things Tailwind genuinely cannot express:
- CSS custom properties (`--accent`, `--bg`, `--fg`, `--muted`, `--card`, `--line`) and `html.dark` overrides
- `repeat(var(--cols), …)` grid (dynamic column count set by media queries)
- Perspective tilt on poster hover
- `@keyframes cardIn` entrance animation
- Title overlay gradient + opacity transition
- Diagonal stripe placeholder
- Range input thumb (no Tailwind thumb utilities)


